### PR TITLE
Add starter Anthropic script and optional BUILD_SPECIFICATION env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,6 @@ STRIPE_WEBHOOK_SECRET=whsec_xxxxx
 # Application
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NODE_ENV=development
+
+# Optional for scripts/anthropic_plan.py
+BUILD_SPECIFICATION="Describe what you want Claude to build"

--- a/scripts/anthropic_plan.py
+++ b/scripts/anthropic_plan.py
@@ -1,0 +1,42 @@
+"""Starter script for generating output from Anthropic based on a build specification."""
+
+from __future__ import annotations
+
+import os
+
+import anthropic
+
+
+def main() -> None:
+    build_specification = os.environ.get(
+        "BUILD_SPECIFICATION",
+        "Replace BUILD_SPECIFICATION with your real prompt text.",
+    )
+
+    client = anthropic.Anthropic(
+        # Defaults to os.environ.get("ANTHROPIC_API_KEY") if omitted.
+        api_key=os.environ.get("ANTHROPIC_API_KEY"),
+    )
+
+    message = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=20_000,
+        temperature=1,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": build_specification,
+                    }
+                ],
+            }
+        ],
+    )
+
+    print(message.content)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a minimal, runnable example that follows the requested plan to call Anthropic from Python without hardcoding credentials. 
- Make it easy to supply prompt content via environment variables so template placeholders can be replaced safely outside source.

### Description
- Add `scripts/anthropic_plan.py`, a small script that reads `BUILD_SPECIFICATION` from the environment, initializes `anthropic.Anthropic` with `ANTHROPIC_API_KEY`, calls `client.messages.create(...)` and prints `message.content`.
- The `messages.create(...)` call uses `model="claude-opus-4-6"`, `max_tokens=20000`, and `temperature=1` to match the requested configuration.
- Update `.env.example` to document the optional `BUILD_SPECIFICATION` environment variable so users can provide prompt text without editing the script.

### Testing
- Ran `python -m py_compile scripts/anthropic_plan.py` to validate the script syntax, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986686ae468832abd4a33f0a5a1a471)