### PR TITLE
Add auth and billing API route unit tests

### DIFF
--- a/PRODUCTION_READINESS.md
+++ b/PRODUCTION_READINESS.md
@@ -119,17 +119,17 @@ Stripe client is initialized but nothing else:
 
 ---
 
-## 4. Testing — Current State: NONE
+## 4. Testing — Current State: PARTIAL
 
 | Test Type | Framework Installed | Tests Written | Coverage |
 |-----------|-------------------|---------------|----------|
-| Unit tests | Vitest 2.0.0 | 0 | 0% |
-| E2E tests | Playwright 1.45.0 | 0 | 0% |
+| Unit tests | Vitest 2.0.0 | 18 files (constants, config, stores, billing, auth, API routes) | Not configured |
+| E2E tests | Playwright 1.45.0 | 1 smoke spec | Not configured |
 | Integration tests | — | 0 | 0% |
 
 **Required before production:**
-- Unit tests for all API routes, auth helpers, state stores
-- Integration tests for tutoring conversation flow
+- Expand unit tests to remaining API surface and error-handling edge cases
+- Integration tests for tutoring conversation flow and persistence behavior
 - E2E tests for student sign-up → session → progress flow
 - E2E tests for educator class management flow
 - Accessibility testing (critical for IEP-accommodated students)

--- a/src/app/api/billing/checkout/__tests__/route.test.ts
+++ b/src/app/api/billing/checkout/__tests__/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireUser = vi.fn();
+const mockCreateCheckoutSession = vi.fn();
+
+vi.mock('@/lib/auth', () => ({ requireUser: mockRequireUser }));
+vi.mock('@/lib/billing', () => ({ createCheckoutSession: mockCreateCheckoutSession }));
+
+describe('POST /api/billing/checkout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_APP_URL = 'https://app.rootwork.test';
+  });
+
+  it('returns checkout URL as JSON for API clients', async () => {
+    const { POST } = await import('../route');
+    mockRequireUser.mockResolvedValue({
+      id: 'user_1',
+      email: 'student@example.com',
+      tenantId: 'tenant_1',
+    });
+    mockCreateCheckoutSession.mockResolvedValue({ url: 'https://checkout.stripe.com/c/session_1' });
+
+    const request = new Request('http://localhost/api/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ tier: 'STARTER' }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ url: 'https://checkout.stripe.com/c/session_1' });
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant_1',
+        userId: 'user_1',
+        tier: 'STARTER',
+      }),
+    );
+  });
+
+  it('redirects HTML clients to checkout', async () => {
+    const { POST } = await import('../route');
+    mockRequireUser.mockResolvedValue({
+      id: 'user_2',
+      email: 'teacher@example.com',
+      tenantId: 'tenant_2',
+    });
+    mockCreateCheckoutSession.mockResolvedValue({ url: 'https://checkout.stripe.com/c/session_2' });
+
+    const request = new Request('http://localhost/api/billing/checkout', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        accept: 'text/html',
+      },
+      body: new URLSearchParams({ tier: 'PROFESSIONAL' }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://checkout.stripe.com/c/session_2');
+  });
+
+  it('returns 400 for invalid payloads', async () => {
+    const { POST } = await import('../route');
+    mockRequireUser.mockResolvedValue({
+      id: 'user_1',
+      email: 'student@example.com',
+      tenantId: 'tenant_1',
+    });
+
+    const request = new Request('http://localhost/api/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ tier: 'INVALID_TIER' }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid request payload.' });
+  });
+});

--- a/src/app/api/billing/portal/__tests__/route.test.ts
+++ b/src/app/api/billing/portal/__tests__/route.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireUser = vi.fn();
+const mockCreateBillingPortalSession = vi.fn();
+
+vi.mock('@/lib/auth', () => ({ requireUser: mockRequireUser }));
+vi.mock('@/lib/billing', () => ({ createBillingPortalSession: mockCreateBillingPortalSession }));
+
+describe('GET /api/billing/portal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_APP_URL = 'https://app.rootwork.test';
+  });
+
+  it('redirects to Stripe billing portal on success', async () => {
+    const { GET } = await import('../route');
+    mockRequireUser.mockResolvedValue({ email: 'owner@example.com', tenantId: 'tenant_1' });
+    mockCreateBillingPortalSession.mockResolvedValue({ url: 'https://billing.stripe.com/p/session_1' });
+
+    const response = await GET();
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://billing.stripe.com/p/session_1');
+  });
+
+  it('redirects back to settings with billing error when a failure occurs', async () => {
+    const { GET } = await import('../route');
+    mockRequireUser.mockRejectedValue(new Error('Unauthorized'));
+
+    const response = await GET();
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://app.rootwork.test/settings?billing=error');
+  });
+});

--- a/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockConstructEvent = vi.fn();
+const mockRetrieveSubscription = vi.fn();
+const mockSyncTenantFromSubscription = vi.fn();
+const mockHandleSubscriptionCanceled = vi.fn();
+
+vi.mock('@/lib/stripe', () => ({
+  stripe: {
+    webhooks: { constructEvent: mockConstructEvent },
+    subscriptions: { retrieve: mockRetrieveSubscription },
+  },
+}));
+
+vi.mock('@/lib/billing', () => ({
+  syncTenantFromSubscription: mockSyncTenantFromSubscription,
+  handleSubscriptionCanceled: mockHandleSubscriptionCanceled,
+}));
+
+describe('POST /api/stripe/webhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test';
+  });
+
+  it('returns 400 when signature or secret is missing', async () => {
+    const { POST } = await import('../route');
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+
+    const request = new Request('http://localhost/api/stripe/webhook', {
+      method: 'POST',
+      body: '{}',
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Webhook signature verification failed.' });
+  });
+
+  it('syncs tenant after checkout session completion with a subscription id', async () => {
+    const { POST } = await import('../route');
+    mockConstructEvent.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: { object: { subscription: 'sub_123' } },
+    });
+    mockRetrieveSubscription.mockResolvedValue({ id: 'sub_123', metadata: { tenantId: 'tenant_1' } });
+
+    const request = new Request('http://localhost/api/stripe/webhook', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'sig_123' },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mockRetrieveSubscription).toHaveBeenCalledWith('sub_123');
+    expect(mockSyncTenantFromSubscription).toHaveBeenCalledWith({ id: 'sub_123', metadata: { tenantId: 'tenant_1' } });
+  });
+
+  it('handles subscription deletion webhooks', async () => {
+    const { POST } = await import('../route');
+    const deletedSubscription = { id: 'sub_456', metadata: { tenantId: 'tenant_2' } };
+    mockConstructEvent.mockReturnValue({
+      type: 'customer.subscription.deleted',
+      data: { object: deletedSubscription },
+    });
+
+    const request = new Request('http://localhost/api/stripe/webhook', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'sig_456' },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(mockHandleSubscriptionCanceled).toHaveBeenCalledWith(deletedSubscription);
+  });
+
+  it('returns 400 when Stripe event parsing fails', async () => {
+    const { POST } = await import('../route');
+    mockConstructEvent.mockImplementation(() => {
+      throw new Error('Bad signature');
+    });
+
+    const request = new Request('http://localhost/api/stripe/webhook', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'sig_invalid' },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid webhook payload.' });
+  });
+});

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAuth = vi.fn();
+const mockDb = {
+  user: {
+    findUnique: vi.fn(),
+  },
+};
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: mockAuth }));
+vi.mock('@/lib/db', () => ({ db: mockDb }));
+
+describe('auth helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when there is no authenticated Clerk user', async () => {
+    const { getCurrentUser } = await import('../auth');
+    mockAuth.mockReturnValue({ userId: null });
+
+    await expect(getCurrentUser()).resolves.toBeNull();
+    expect(mockDb.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('loads the user and role relationships when a Clerk user exists', async () => {
+    const { getCurrentUser } = await import('../auth');
+    mockAuth.mockReturnValue({ userId: 'clerk_123' });
+    mockDb.user.findUnique.mockResolvedValue({ id: 'user_1', role: 'STUDENT' });
+
+    const user = await getCurrentUser();
+
+    expect(user).toEqual({ id: 'user_1', role: 'STUDENT' });
+    expect(mockDb.user.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clerkUserId: 'clerk_123' },
+        include: {
+          student: true,
+          educator: true,
+          parent: true,
+          tenant: true,
+        },
+      }),
+    );
+  });
+
+  it('throws Unauthorized when requireUser is called without an authenticated user', async () => {
+    const { requireUser } = await import('../auth');
+    mockAuth.mockReturnValue({ userId: null });
+
+    await expect(requireUser()).rejects.toThrow('Unauthorized');
+  });
+
+  it('throws Forbidden when requireRole does not include the user role', async () => {
+    const { requireRole } = await import('../auth');
+    mockAuth.mockReturnValue({ userId: 'clerk_123' });
+    mockDb.user.findUnique.mockResolvedValue({ id: 'user_1', role: 'STUDENT' });
+
+    await expect(requireRole(['EDUCATOR'])).rejects.toThrow('Forbidden');
+  });
+
+  it('returns user when requireRole includes the current user role', async () => {
+    const { requireRole } = await import('../auth');
+    mockAuth.mockReturnValue({ userId: 'clerk_123' });
+    mockDb.user.findUnique.mockResolvedValue({ id: 'user_1', role: 'EDUCATOR' });
+
+    await expect(requireRole(['EDUCATOR'])).resolves.toEqual({ id: 'user_1', role: 'EDUCATOR' });
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve automated test coverage for authentication helpers and billing-related API routes to raise production readiness signaling.
- Reflect the new test baseline in the project readiness documentation so the status is accurate.

### Description
- Add `src/lib/__tests__/auth.test.ts` to validate `getCurrentUser`, `requireUser`, and `requireRole` behaviors with mocked Clerk and DB interactions.
- Add API route unit tests for billing and webhooks in `src/app/api/billing/checkout/__tests__/route.test.ts`, `src/app/api/billing/portal/__tests__/route.test.ts`, and `src/app/api/stripe/webhook/__tests__/route.test.ts` covering JSON responses, HTML redirects, signature/secret validation, subscription sync, and deletion handling.
- Update `PRODUCTION_READINESS.md` testing section from `NONE` to `PARTIAL` to document the added unit tests and current gaps.
- No production code behavior was changed; this PR only adds tests and documentation updates.

### Testing
- Ran the test suite with `npm test -- --run` using Vitest and all tests completed successfully.
- Test run summary: 18 test files, 218 tests passed (no failures), confirming the new test suites integrate with the existing test harness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a1304fa4832a97741c68817f448a)