### PR TITLE
Add K-12 compliance baseline: consent & data-rights APIs, policy pages, retention

### DIFF
--- a/src/app/api/compliance/consent/route.ts
+++ b/src/app/api/compliance/consent/route.ts
@@ -1,0 +1,116 @@
+import { ConsentStatus } from '@prisma/client';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireUser } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { canManageMinorConsent, isConsentStatusTransitionAllowed } from '@/lib/compliance';
+
+const updateConsentSchema = z.object({
+  studentUserId: z.string().min(1),
+  consentStatus: z.enum(['PENDING', 'GRANTED', 'DENIED', 'WITHDRAWN']),
+  method: z.string().min(2).max(100).optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+export async function GET(request: Request) {
+  const actor = await requireUser();
+  const url = new URL(request.url);
+  const studentUserId = url.searchParams.get('studentUserId') || actor.id;
+
+  if (studentUserId !== actor.id && !canManageMinorConsent(actor.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const student = await db.user.findUnique({
+    where: { id: studentUserId },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      isMinor: true,
+      consentStatus: true,
+      updatedAt: true,
+    },
+  });
+
+  if (!student) {
+    return NextResponse.json({ error: 'Student not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ consent: student });
+}
+
+export async function POST(request: Request) {
+  try {
+    const actor = await requireUser();
+    if (!canManageMinorConsent(actor.role)) {
+      return NextResponse.json({ error: 'Only parent/admin roles can update consent status' }, { status: 403 });
+    }
+
+    const payload = updateConsentSchema.parse(await request.json());
+
+    const student = await db.user.findUnique({
+      where: { id: payload.studentUserId },
+      select: {
+        id: true,
+        tenantId: true,
+        isMinor: true,
+        consentStatus: true,
+      },
+    });
+
+    if (!student) {
+      return NextResponse.json({ error: 'Student not found' }, { status: 404 });
+    }
+
+    if (!student.isMinor) {
+      return NextResponse.json({ error: 'Consent workflow applies only to minor accounts' }, { status: 400 });
+    }
+
+    const currentStatus = student.consentStatus as ConsentStatus | null;
+    if (!isConsentStatusTransitionAllowed(currentStatus, payload.consentStatus)) {
+      return NextResponse.json(
+        { error: `Invalid consent status transition from ${currentStatus ?? 'UNSET'} to ${payload.consentStatus}` },
+        { status: 400 }
+      );
+    }
+
+    const updated = await db.user.update({
+      where: { id: student.id },
+      data: {
+        consentStatus: payload.consentStatus,
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        consentStatus: true,
+        updatedAt: true,
+      },
+    });
+
+    await db.auditLog.create({
+      data: {
+        tenantId: student.tenantId,
+        userId: actor.id,
+        action: 'CONSENT_STATUS_UPDATED',
+        resource: 'User',
+        resourceId: student.id,
+        metadata: {
+          previousStatus: currentStatus,
+          nextStatus: payload.consentStatus,
+          method: payload.method,
+          notes: payload.notes,
+        },
+      },
+    });
+
+    return NextResponse.json({ success: true, consent: updated });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Invalid request payload', issues: error.issues }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: 'Unable to update consent status' }, { status: 500 });
+  }
+}

--- a/src/app/api/compliance/data-rights/route.ts
+++ b/src/app/api/compliance/data-rights/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireUser } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { canManageMinorConsent, requiresGuardianForDataRequest } from '@/lib/compliance';
+
+const dataRightsSchema = z.object({
+  requestType: z.enum(['EXPORT', 'DELETE']),
+  subjectUserId: z.string().optional(),
+  reason: z.string().max(1000).optional(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const actor = await requireUser();
+    const payload = dataRightsSchema.parse(await request.json());
+    const subjectUserId = payload.subjectUserId ?? actor.id;
+
+    const subject = await db.user.findUnique({
+      where: { id: subjectUserId },
+      include: {
+        student: {
+          include: {
+            sessions: {
+              include: {
+                messages: true,
+                assessments: true,
+              },
+            },
+            progress: true,
+          },
+        },
+      },
+    });
+
+    if (!subject) {
+      return NextResponse.json({ error: 'Requested user was not found' }, { status: 404 });
+    }
+
+    const sameUser = actor.id === subject.id;
+    if (!sameUser && !canManageMinorConsent(actor.role)) {
+      return NextResponse.json({ error: 'Forbidden for requested subject' }, { status: 403 });
+    }
+
+    if (requiresGuardianForDataRequest(subject.isMinor, actor.role)) {
+      return NextResponse.json({ error: 'A parent/admin role is required for minor data requests' }, { status: 403 });
+    }
+
+    await db.auditLog.create({
+      data: {
+        tenantId: subject.tenantId,
+        userId: actor.id,
+        action: 'DATA_RIGHTS_REQUESTED',
+        resource: 'User',
+        resourceId: subject.id,
+        metadata: {
+          requestType: payload.requestType,
+          reason: payload.reason,
+        },
+      },
+    });
+
+    if (payload.requestType === 'DELETE') {
+      return NextResponse.json({
+        success: true,
+        status: 'QUEUED',
+        message: 'Deletion request logged. Fulfillment requires privacy admin review before irreversible removal.',
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      export: {
+        generatedAt: new Date().toISOString(),
+        subject: {
+          id: subject.id,
+          email: subject.email,
+          firstName: subject.firstName,
+          lastName: subject.lastName,
+          role: subject.role,
+          isMinor: subject.isMinor,
+          consentStatus: subject.consentStatus,
+          createdAt: subject.createdAt,
+        },
+        learningDataSummary: {
+          totalSessions: subject.student?.sessions.length ?? 0,
+          totalMessages:
+            subject.student?.sessions.reduce((sum, session) => sum + session.messages.length, 0) ?? 0,
+          totalAssessments:
+            subject.student?.sessions.reduce((sum, session) => sum + session.assessments.length, 0) ?? 0,
+          progressRecords: subject.student?.progress.length ?? 0,
+        },
+      },
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Invalid request payload', issues: error.issues }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: 'Unable to process data-rights request' }, { status: 500 });
+  }
+}

--- a/src/app/data-retention/page.tsx
+++ b/src/app/data-retention/page.tsx
@@ -1,0 +1,36 @@
+import { retentionPolicyRecords } from '@/lib/compliance';
+
+export default function DataRetentionPage() {
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-12">
+      <h1 className="text-3xl font-bold text-neutral-900">Data Retention & Lifecycle Policy</h1>
+      <p className="mt-4 text-neutral-700">
+        This policy defines how long RootWork keeps education records and how records are anonymized or deleted once
+        retention windows end.
+      </p>
+
+      <div className="mt-8 overflow-x-auto rounded-lg border border-neutral-200">
+        <table className="min-w-full text-left text-sm text-neutral-700">
+          <thead className="bg-neutral-50">
+            <tr>
+              <th className="px-4 py-3">Data category</th>
+              <th className="px-4 py-3">Retention period</th>
+              <th className="px-4 py-3">Legal basis</th>
+              <th className="px-4 py-3">End-of-life handling</th>
+            </tr>
+          </thead>
+          <tbody>
+            {retentionPolicyRecords.map((record) => (
+              <tr key={record.category} className="border-t border-neutral-200">
+                <td className="px-4 py-3">{record.category}</td>
+                <td className="px-4 py-3">{record.retentionPeriod}</td>
+                <td className="px-4 py-3">{record.legalBasis}</td>
+                <td className="px-4 py-3">{record.deletionMethod}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </main>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,11 +1,62 @@
+import { retentionPolicyRecords } from '@/lib/compliance';
+
 export default function PrivacyPage() {
   return (
-    <main className="mx-auto max-w-3xl px-6 py-12">
-      <h1 className="text-3xl font-bold text-neutral-900">Privacy</h1>
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      <h1 className="text-3xl font-bold text-neutral-900">Privacy Policy (Draft for School Partner Review)</h1>
       <p className="mt-4 text-neutral-700">
-        RootWork is designed for educational contexts and minimizes personal data usage. Detailed privacy policy text
-        will be finalized before production launch.
+        RootWork is built for K-12 settings and follows privacy-by-design principles to limit personal data collection,
+        protect student learning records, and support parent rights. This draft summarizes current controls while legal
+        counsel finalizes launch language.
       </p>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-xl font-semibold text-neutral-900">Data we collect</h2>
+        <ul className="list-disc space-y-2 pl-6 text-neutral-700">
+          <li>Account identifiers (name, email, role, school/tenant association).</li>
+          <li>Learning interaction data (session transcripts, assessment responses, progress signals).</li>
+          <li>Safety and compliance events (consent changes, admin actions, security logs).</li>
+        </ul>
+      </section>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-xl font-semibold text-neutral-900">How we use data</h2>
+        <ul className="list-disc space-y-2 pl-6 text-neutral-700">
+          <li>Deliver adaptive tutoring and progress insights requested by schools and families.</li>
+          <li>Meet legal obligations including COPPA/FERPA-aligned consent and record-keeping workflows.</li>
+          <li>Support platform security, abuse prevention, and operational reliability.</li>
+        </ul>
+      </section>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-xl font-semibold text-neutral-900">Parent and student rights</h2>
+        <p className="text-neutral-700">
+          Parents/guardians can request consent updates, data export, and data deletion review through support channels
+          or the compliance API endpoints. Minor data requests require parent/admin authorization.
+        </p>
+      </section>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-xl font-semibold text-neutral-900">Retention snapshot</h2>
+        <div className="rounded-lg border border-neutral-200">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-neutral-50 text-neutral-700">
+              <tr>
+                <th className="px-4 py-3">Category</th>
+                <th className="px-4 py-3">Retention</th>
+              </tr>
+            </thead>
+            <tbody>
+              {retentionPolicyRecords.map((record) => (
+                <tr key={record.category} className="border-t border-neutral-200 text-neutral-700">
+                  <td className="px-4 py-3">{record.category}</td>
+                  <td className="px-4 py-3">{record.retentionPeriod}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,11 +1,43 @@
 export default function TermsPage() {
   return (
-    <main className="mx-auto max-w-3xl px-6 py-12">
-      <h1 className="text-3xl font-bold text-neutral-900">Terms of Use</h1>
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      <h1 className="text-3xl font-bold text-neutral-900">Terms of Use (Draft)</h1>
       <p className="mt-4 text-neutral-700">
-        Terms are currently in draft while the platform is in early-phase development. A full legal document will be
-        published before public release.
+        These draft terms describe pilot usage of RootWork by schools, educators, parents, and students. Final legal
+        terms will be executed per district contract before production launch.
       </p>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-xl font-semibold text-neutral-900">Eligibility and account roles</h2>
+        <p className="text-neutral-700">
+          Accounts are provisioned through school-authorized channels. Student access may require documented parental
+          consent based on age, school policy, and applicable law.
+        </p>
+      </section>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-xl font-semibold text-neutral-900">Acceptable use</h2>
+        <ul className="list-disc space-y-2 pl-6 text-neutral-700">
+          <li>No misuse, tampering, or unauthorized access attempts.</li>
+          <li>No uploading unlawful or harmful content to tutoring experiences.</li>
+          <li>Educators and admins are responsible for accurate roster and consent management.</li>
+        </ul>
+      </section>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-xl font-semibold text-neutral-900">Compliance and records</h2>
+        <p className="text-neutral-700">
+          RootWork logs key administrative and privacy events to support FERPA/COPPA compliance workflows and audit
+          readiness. Contracting institutions remain data controllers for student education records.
+        </p>
+      </section>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-xl font-semibold text-neutral-900">Changes to these terms</h2>
+        <p className="text-neutral-700">
+          We will provide notice of material changes and maintain version history for school partners and families.
+        </p>
+      </section>
     </main>
   );
 }

--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -161,6 +161,7 @@ describe('siteConfig', () => {
     expect(siteConfig.links).toHaveProperty('methodology');
     expect(siteConfig.links).toHaveProperty('privacy');
     expect(siteConfig.links).toHaveProperty('terms');
+    expect(siteConfig.links).toHaveProperty('dataRetention');
   });
 });
 

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -11,5 +11,6 @@ export const siteConfig = {
     methodology: '/methodology',
     privacy: '/privacy',
     terms: '/terms',
+    dataRetention: '/data-retention',
   },
 } as const;

--- a/src/lib/__tests__/compliance.test.ts
+++ b/src/lib/__tests__/compliance.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canManageMinorConsent,
+  isConsentStatusTransitionAllowed,
+  retentionPolicyRecords,
+  requiresGuardianForDataRequest,
+} from '@/lib/compliance';
+
+describe('compliance utilities', () => {
+  it('allows only guardian/admin roles to manage minor consent', () => {
+    expect(canManageMinorConsent('PARENT')).toBe(true);
+    expect(canManageMinorConsent('SCHOOL_ADMIN')).toBe(true);
+    expect(canManageMinorConsent('STUDENT')).toBe(false);
+  });
+
+  it('validates consent status transitions', () => {
+    expect(isConsentStatusTransitionAllowed(null, 'PENDING')).toBe(true);
+    expect(isConsentStatusTransitionAllowed('GRANTED', 'WITHDRAWN')).toBe(true);
+    expect(isConsentStatusTransitionAllowed('GRANTED', 'DENIED')).toBe(false);
+  });
+
+  it('requires guardian role for minor data-rights requests', () => {
+    expect(requiresGuardianForDataRequest(true, 'STUDENT')).toBe(true);
+    expect(requiresGuardianForDataRequest(true, 'PARENT')).toBe(false);
+    expect(requiresGuardianForDataRequest(false, 'STUDENT')).toBe(false);
+  });
+
+  it('defines retention categories for legal readiness', () => {
+    expect(retentionPolicyRecords.length).toBeGreaterThanOrEqual(4);
+    expect(retentionPolicyRecords.some((record) => record.category.includes('consent'))).toBe(true);
+  });
+});

--- a/src/lib/compliance.ts
+++ b/src/lib/compliance.ts
@@ -1,0 +1,62 @@
+import { ConsentStatus, UserRole } from '@prisma/client';
+
+export const guardianRoles: UserRole[] = ['PARENT', 'SCHOOL_ADMIN', 'DISTRICT_ADMIN', 'PLATFORM_ADMIN'];
+
+export function canManageMinorConsent(role: UserRole): boolean {
+  return guardianRoles.includes(role);
+}
+
+export function isConsentStatusTransitionAllowed(current: ConsentStatus | null, next: ConsentStatus): boolean {
+  if (!current) {
+    return next === 'PENDING' || next === 'GRANTED' || next === 'DENIED';
+  }
+
+  const allowedTransitions: Record<ConsentStatus, ConsentStatus[]> = {
+    PENDING: ['GRANTED', 'DENIED', 'WITHDRAWN'],
+    GRANTED: ['WITHDRAWN'],
+    DENIED: ['PENDING', 'GRANTED'],
+    WITHDRAWN: ['PENDING', 'GRANTED'],
+  };
+
+  return allowedTransitions[current].includes(next);
+}
+
+export type RetentionPolicyRecord = {
+  category: string;
+  retentionPeriod: string;
+  legalBasis: string;
+  deletionMethod: string;
+};
+
+export const retentionPolicyRecords: RetentionPolicyRecord[] = [
+  {
+    category: 'Student learning session transcripts',
+    retentionPeriod: '24 months after the last activity date',
+    legalBasis: 'FERPA school official interest and educational continuity',
+    deletionMethod: 'Automated soft-delete followed by 30-day hard-delete purge',
+  },
+  {
+    category: 'Assessment outcomes and mastery records',
+    retentionPeriod: '36 months after school year close',
+    legalBasis: 'District reporting obligations and instructional planning',
+    deletionMethod: 'Scheduled anonymization with aggregate-only retention',
+  },
+  {
+    category: 'Parental consent records and revocations',
+    retentionPeriod: '7 years from consent action',
+    legalBasis: 'COPPA consent evidence and legal defensibility',
+    deletionMethod: 'Encrypted archive with expiration-based destruction',
+  },
+  {
+    category: 'Security and compliance audit logs',
+    retentionPeriod: '13 months rolling',
+    legalBasis: 'Security incident response and SOC 2 evidence collection',
+    deletionMethod: 'Immutable log rotation and secure archival destruction',
+  },
+];
+
+export type DataRightsRequestType = 'EXPORT' | 'DELETE';
+
+export function requiresGuardianForDataRequest(isMinor: boolean, role: UserRole): boolean {
+  return isMinor && !canManageMinorConsent(role);
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, high-impact compliance baseline for a K-12 platform by adding parental consent workflows and data-rights handling. 
- Capture audit evidence and retention guidance to support COPPA/FERPA readiness and legal review. 
- Surface privacy and terms content for school partners while legal language is finalized. 
- Add simple, testable utilities to centralize consent rules and retention categories for later automation.

### Description
- Add a new compliance utility module `src/lib/compliance.ts` implementing role checks (`canManageMinorConsent`), consent transition validation (`isConsentStatusTransitionAllowed`), retention records (`retentionPolicyRecords`) and minor data-request guards (`requiresGuardianForDataRequest`).
- Implement `GET`/`POST /api/compliance/consent` at `src/app/api/compliance/consent/route.ts` to read and update a minor's `consentStatus` with validation, authorization, and `AuditLog` writes. 
- Implement `POST /api/compliance/data-rights` at `src/app/api/compliance/data-rights/route.ts` to queue `DELETE` requests and return `EXPORT` packages for authorized subjects, and to record requests in `AuditLog`. 
- Expand legal pages: replace privacy/terms stubs with draft content and add a `Data Retention & Lifecycle Policy` page at `src/app/data-retention/page.tsx`. 
- Add `dataRetention` to `siteConfig` links (`src/config/site.ts`) and update tests using that link. 
- Add unit tests for the compliance utilities at `src/lib/__tests__/compliance.test.ts` and update `src/config/__tests__/config.test.ts` to assert the new link.

### Testing
- Ran unit tests with `npm run test -- --run src/lib/__tests__/compliance.test.ts src/config/__tests__/config.test.ts`; both test files ran and all tests passed (34 tests total). 
- Ran lint with `npm run lint`; no ESLint warnings or errors. 
- Attempted production build with `npm run build`; build failed due to unrelated missing UI module resolution for `@radix-ui/react-progress` and `@radix-ui/react-radio-group` in existing components (existing, unrelated UI dependency issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a2c8ba44832a9b3368a71de1ca40)