### PR TITLE
Add setup script for RAG + n8n onboarding and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,33 @@ A comprehensive AI-powered learning platform with multi-tenancy support, trauma-
    - `ANTHROPIC_API_KEY`: Anthropic AI API key
    - Other required environment variables (see `.env.example`)
 
+
+### RAG + n8n Curriculum Ingest Setup
+
+Use the automation script below to set required API keys, create the Pinecone index, and set GitHub secrets for your curriculum content repository.
+
+```bash
+export OPENAI_API_KEY="<your-openai-key>"
+export PINECONE_API_KEY="<your-pinecone-key>"
+export N8N_WEBHOOK_URL="https://<your-n8n-host>/webhook/curriculum-ingest"
+export N8N_WEBHOOK_SECRET="<your-webhook-secret>"
+export CURRICULUM_REPO="<org-or-user>/<curriculum-repo>"
+
+./scripts/setup-rag-n8n.sh
+```
+
+What the script does:
+- Writes `OPENAI_API_KEY` and `PINECONE_API_KEY` into `.env.local`
+- Runs `npm run rag:create-index`
+- Prompts you to import `scripts/n8n-workflow.json` in n8n and attach GitHub credentials
+- Sets `N8N_WEBHOOK_URL` and `N8N_WEBHOOK_SECRET` with `gh secret set`
+
+If you only want to update env vars and GitHub secrets without creating the index:
+
+```bash
+SKIP_INDEX_CREATE=1 ./scripts/setup-rag-n8n.sh
+```
+
 ### Database Setup
 
 #### Apply Migrations to a Fresh Database

--- a/scripts/setup-rag-n8n.sh
+++ b/scripts/setup-rag-n8n.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env.local"
+WORKFLOW_FILE="${ROOT_DIR}/scripts/n8n-workflow.json"
+
+require_var() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "❌ Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+}
+
+upsert_env() {
+  local key="$1"
+  local value="$2"
+  if [[ -f "$ENV_FILE" ]] && rg -q "^${key}=" "$ENV_FILE"; then
+    python - "$ENV_FILE" "$key" "$value" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+key = sys.argv[2]
+value = sys.argv[3]
+text = path.read_text()
+text = re.sub(rf"^{re.escape(key)}=.*$", f"{key}={value}", text, flags=re.M)
+path.write_text(text)
+PY
+  else
+    echo "${key}=${value}" >> "$ENV_FILE"
+  fi
+}
+
+require_var OPENAI_API_KEY
+require_var PINECONE_API_KEY
+require_var N8N_WEBHOOK_URL
+require_var N8N_WEBHOOK_SECRET
+require_var CURRICULUM_REPO
+
+touch "$ENV_FILE"
+upsert_env OPENAI_API_KEY "$OPENAI_API_KEY"
+upsert_env PINECONE_API_KEY "$PINECONE_API_KEY"
+upsert_env N8N_WEBHOOK_URL "$N8N_WEBHOOK_URL"
+upsert_env N8N_WEBHOOK_SECRET "$N8N_WEBHOOK_SECRET"
+
+echo "✅ Updated ${ENV_FILE} with required RAG + n8n variables."
+
+if [[ "${SKIP_INDEX_CREATE:-0}" != "1" ]]; then
+  echo "▶ Running npm run rag:create-index"
+  (cd "$ROOT_DIR" && npm run rag:create-index)
+else
+  echo "⚠️ SKIP_INDEX_CREATE=1 set; skipping npm run rag:create-index"
+fi
+
+echo "\n📥 n8n import"
+echo "1) In n8n, open Workflows → Import from File."
+echo "2) Select: ${WORKFLOW_FILE}"
+echo "3) Edit node 'Fetch File from GitHub' and attach your GitHub credential."
+
+echo "\n🔐 GitHub secrets"
+if command -v gh >/dev/null 2>&1; then
+  if gh auth status >/dev/null 2>&1; then
+    gh secret set N8N_WEBHOOK_URL --repo "$CURRICULUM_REPO" --body "$N8N_WEBHOOK_URL"
+    gh secret set N8N_WEBHOOK_SECRET --repo "$CURRICULUM_REPO" --body "$N8N_WEBHOOK_SECRET"
+    echo "✅ Set N8N_WEBHOOK_URL and N8N_WEBHOOK_SECRET on ${CURRICULUM_REPO}."
+  else
+    echo "⚠️ gh CLI is installed but not authenticated. Run manually after 'gh auth login':"
+    echo "   gh secret set N8N_WEBHOOK_URL --repo ${CURRICULUM_REPO} --body \"${N8N_WEBHOOK_URL}\""
+    echo "   gh secret set N8N_WEBHOOK_SECRET --repo ${CURRICULUM_REPO} --body \"${N8N_WEBHOOK_SECRET}\""
+  fi
+else
+  echo "⚠️ gh CLI not installed. Run manually:"
+  echo "   gh secret set N8N_WEBHOOK_URL --repo ${CURRICULUM_REPO} --body \"${N8N_WEBHOOK_URL}\""
+  echo "   gh secret set N8N_WEBHOOK_SECRET --repo ${CURRICULUM_REPO} --body \"${N8N_WEBHOOK_SECRET}\""
+fi


### PR DESCRIPTION
### Motivation

- Make it easy to configure RAG (OpenAI embeddings + Pinecone) and n8n curriculum ingest by automating environment variable population and onboarding steps. 
- Provide a reproducible local helper to create the Pinecone index and wire up GitHub secrets for curriculum repositories. 

### Description

- Add `scripts/setup-rag-n8n.sh`, a helper that validates required env vars, upserts `OPENAI_API_KEY`, `PINECONE_API_KEY`, `N8N_WEBHOOK_URL`, and `N8N_WEBHOOK_SECRET` into `.env.local`, and supports `SKIP_INDEX_CREATE=1` to skip index creation. 
- The script runs `npm run rag:create-index` (unless skipped), prints instructions to import `scripts/n8n-workflow.json` into n8n and attach GitHub credentials, and attempts to set repository secrets using `gh` while handling unauthenticated or missing `gh` cases. 
- Update `README.md` with a new “RAG + n8n Curriculum Ingest Setup” section including usage examples and the `SKIP_INDEX_CREATE` option. 

### Testing

- Ran a syntax check with `bash -n scripts/setup-rag-n8n.sh`, which succeeded. 
- Executed the script with test environment variables and `SKIP_INDEX_CREATE=1` using `OPENAI_API_KEY=test-openai PINECONE_API_KEY=test-pinecone N8N_WEBHOOK_URL=https://example.com/webhook/curriculum-ingest N8N_WEBHOOK_SECRET=whsec_test CURRICULUM_REPO=octo-org/curriculum SKIP_INDEX_CREATE=1 ./scripts/setup-rag-n8n.sh`, which succeeded and updated `.env.local` and printed manual `gh` instructions. 
- Attempted to run `OPENAI_API_KEY=test-openai PINECONE_API_KEY=test-pinecone npm run rag:create-index`, which failed because the environment lacked the `@pinecone-database/pinecone` dependency. 
- Attempted `npm install` to install dependencies, which failed in this environment due to an npm registry 403 error, preventing full index creation and live Pinecone validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987cf5f8500832a93776452f50b43d5)