### PR TITLE
Fix conclusion content routing: add proper conclusion and populate im…

### DIFF
--- a/12-implementation/part-1.md
+++ b/12-implementation/part-1.md
@@ -1,3 +1,100 @@
-# Implementation Guide Part 1
+# Implementation Guide Part 1: Readiness Assessment and Initial Planning
 
-Content for part 1 of the implementation guide.
+## Overview
+
+Successful implementation of the FG2G curriculum begins well before the first seed is planted. This section guides schools and districts through the readiness assessment, stakeholder engagement, and foundational planning needed to launch a garden-based, trauma-informed learning program.
+
+## Phase 1: Readiness Assessment (Months 1-3)
+
+### Organizational Capacity Review
+
+Before committing to implementation, conduct an honest assessment of your school or district's current capacity:
+
+#### Staffing and Expertise
+- **Educator readiness**: How many staff members have training in trauma-informed practices? In garden-based education?
+- **Administrative support**: Is there a designated administrator who will champion the program?
+- **Support staff**: Are counselors, social workers, and special educators prepared to integrate garden-based approaches?
+- **Maintenance**: Who will maintain garden spaces during breaks and summer months?
+
+#### Physical Resources
+- **Available land**: Identify potential garden sites — rooftops, courtyards, unused fields, raised bed areas, or indoor growing spaces.
+- **Water access**: Confirm proximity to water sources for irrigation.
+- **Sunlight**: Assess sun exposure across seasons (minimum 6 hours daily for most food crops).
+- **Soil quality**: Conduct soil testing for contaminants, especially in urban settings, before any planting.
+- **Tool storage**: Identify or plan secure storage for garden tools and supplies.
+
+#### Financial Resources
+- **Startup costs**: Estimate initial investment for garden construction, soil, tools, seeds, and infrastructure.
+- **Ongoing costs**: Project annual maintenance, replacement supplies, and professional development expenses.
+- **Funding sources**: Identify grants, district allocations, community donations, and parent organization support.
+
+### Stakeholder Mapping and Engagement
+
+Identify and engage key stakeholders early:
+
+| Stakeholder Group | Role in Implementation | Engagement Strategy |
+|---|---|---|
+| Teachers | Primary curriculum deliverers | Professional development, planning time, input on design |
+| Administrators | Resource allocation, scheduling | Regular briefings, data on outcomes, site visits to model programs |
+| Students | Learners and garden stewards | Voice and choice in garden design, leadership roles |
+| Families | Home-garden connection, volunteers | Information sessions, family garden events, take-home activities |
+| School counselors | Trauma-informed practice support | Co-planning, integration with existing SEL programs |
+| Custodial staff | Facility and grounds coordination | Early consultation on logistics, maintenance planning |
+| Community partners | Expertise, resources, mentorship | Partnership agreements, shared goals, clear roles |
+| School board | Policy and budget approval | Presentations with evidence base, pilot proposals |
+
+### Baseline Data Collection
+
+Gather baseline data to measure impact later:
+
+- **Academic metrics**: Standardized test scores, grades, course completion rates for target populations.
+- **Behavioral data**: Office referrals, suspensions, attendance rates.
+- **Social-emotional measures**: SEL survey data, school climate surveys.
+- **Health indicators**: If available, physical activity levels, nutrition knowledge.
+- **Teacher well-being**: Staff satisfaction surveys, retention rates.
+
+## Phase 2: Design and Planning (Months 3-6)
+
+### Forming the Implementation Team
+
+Establish a core team of 5-8 members:
+
+- **Program coordinator** (lead): Manages timeline, communication, and logistics.
+- **Lead educator(s)**: 2-3 teachers who will pilot the curriculum.
+- **Administrator**: Ensures scheduling, budgeting, and policy alignment.
+- **Counselor/social worker**: Guides trauma-informed practice integration.
+- **Community partner representative**: Connects to external resources and expertise.
+- **Parent/family representative**: Ensures family voice in planning.
+- **Student representative** (grades 6-12): Provides youth perspective.
+
+### Developing the Implementation Timeline
+
+Create a realistic timeline aligned with the school calendar:
+
+| Month | Milestone |
+|---|---|
+| 1-3 | Readiness assessment complete; stakeholders engaged |
+| 3-6 | Garden site designed; curriculum scope and sequence drafted; PD plan created |
+| 6-9 | Garden construction; initial professional development; materials procured |
+| 9-12 | Pilot launch with 2-3 classrooms; formative assessment begins |
+| 12-18 | Expand to additional classrooms based on pilot data; refine curriculum |
+| 18-24 | Full implementation across target grade bands; summative assessment |
+
+### Budget Planning
+
+#### Startup Budget Categories
+
+- **Garden infrastructure**: Raised beds, soil, irrigation, fencing, pathways, accessible design elements.
+- **Tools and supplies**: Hand tools (child-sized for K-2), wheelbarrows, watering cans, harvest baskets.
+- **Seeds and plants**: Culturally relevant varieties, perennials for long-term gardens, cover crops.
+- **Curriculum materials**: Print resources, assessment tools, student journals.
+- **Professional development**: Trainer fees, substitute coverage, stipends for planning time.
+- **Technology**: Data collection tools, documentation equipment.
+
+#### Sustainability Planning
+
+Budget for sustainability from day one:
+- Annual soil amendment and seed costs.
+- Tool replacement on a 3-year cycle.
+- Ongoing professional development for new staff.
+- Program evaluation costs.

--- a/12-implementation/part-2.md
+++ b/12-implementation/part-2.md
@@ -1,3 +1,119 @@
-# Implementation Guide Part 2
+# Implementation Guide Part 2: Professional Development and Pilot Launch
 
-Content for part 2 of the implementation guide.
+## Quarter 1 (Months 1-6): Building Educator Capacity
+
+### Professional Development Sequence
+
+Effective FG2G implementation requires educators who are confident in both trauma-informed practice and garden-based instruction. The professional development sequence should be completed before the pilot launch.
+
+#### Foundation Training (Months 1-2)
+
+**Module 1: Understanding ACEs and Trauma-Informed Education** (8 hours)
+- Prevalence and impact of adverse childhood experiences.
+- How trauma affects learning, behavior, and brain development.
+- Shifting from "What's wrong with you?" to "What happened to you?"
+- School-wide trauma-informed practices vs. individual interventions.
+
+**Module 2: The 5Rs Framework in Practice** (8 hours)
+- Deep dive into Root, Regulate, Reconnect, Restore, and Reflect.
+- Identifying 5Rs opportunities in daily instruction.
+- Regulation strategies for the garden and classroom.
+- Adapting the 5Rs across grade bands.
+
+**Module 3: Garden-Based Education Fundamentals** (8 hours)
+- Principles of therapeutic horticulture.
+- Academic integration through garden activities.
+- Seasonal planning for school gardens.
+- Safety protocols and risk management.
+
+#### Applied Training (Months 3-4)
+
+**Module 4: Curriculum Integration Workshop** (6 hours)
+- Mapping FG2G lessons to existing standards and pacing guides.
+- Co-planning garden-based units with grade-level teams.
+- Differentiation strategies for diverse learners.
+- IEP and 504 accommodation planning for garden activities.
+
+**Module 5: Assessment in the Garden** (4 hours)
+- Portfolio-based assessment design.
+- Rubric development for garden projects.
+- Observational assessment techniques.
+- Integrating SEL measurement with academic assessment.
+
+**Module 6: Practicum** (ongoing, Months 4-6)
+- Supervised garden sessions with students.
+- Peer observation and feedback cycles.
+- Reflective journaling on practice.
+- Mentorship from experienced garden educators.
+
+### Coaching and Mentorship Model
+
+Pair each pilot educator with:
+- **An instructional coach** who understands trauma-informed pedagogy.
+- **A garden mentor** — a master gardener, extension agent, or experienced garden educator.
+- **A peer partner** — another pilot educator for mutual support and accountability.
+
+### Creating a Professional Learning Community
+
+Establish a monthly PLC for FG2G educators:
+- Share successes and challenges from garden instruction.
+- Review student work and assessment data collaboratively.
+- Refine lessons based on classroom experience.
+- Build collective expertise and institutional knowledge.
+
+## Quarter 2 (Months 7-9): Pilot Launch
+
+### Selecting Pilot Classrooms
+
+Choose 2-3 classrooms for the initial pilot based on:
+- **Teacher readiness**: Educators who have completed PD and express enthusiasm.
+- **Student need**: Classrooms serving students who may benefit most from trauma-informed, experiential approaches.
+- **Grade band representation**: Include at least two grade bands to test curriculum across developmental levels.
+- **Logistical feasibility**: Proximity to garden space, scheduling flexibility.
+
+### Pilot Launch Checklist
+
+#### Garden Space
+- [ ] Garden beds constructed and filled with tested, clean soil.
+- [ ] Irrigation system installed and tested.
+- [ ] Pathways are accessible (ADA compliant).
+- [ ] Tool storage is secure, organized, and labeled.
+- [ ] Safety signage posted (sunscreen reminders, hand-washing, tool handling).
+- [ ] Sensory-friendly quiet area established within or adjacent to garden.
+
+#### Curriculum
+- [ ] Scope and sequence finalized for pilot grade bands.
+- [ ] Lesson plans reviewed and adapted for local context.
+- [ ] Student journals and materials printed or assembled.
+- [ ] Assessment tools (rubrics, portfolio templates, observation forms) prepared.
+
+#### Communication
+- [ ] Families informed via letter, meeting, or digital communication.
+- [ ] Permission forms collected for outdoor activities.
+- [ ] Allergy and medical information reviewed for all participating students.
+- [ ] Schedule communicated to all affected staff (specials, lunch, recess).
+
+#### Data Collection
+- [ ] Baseline assessments administered.
+- [ ] Data collection protocols established.
+- [ ] IRB approval obtained if conducting formal research.
+
+### First Weeks of Implementation
+
+**Week 1-2: Establishing the Garden as a Learning Space**
+- Introduce garden expectations and routines (the "Root" phase).
+- Practice transitions between classroom and garden.
+- Teach and practice regulation strategies for the outdoor space.
+- Begin garden journals.
+
+**Week 3-4: Building Community**
+- Collaborative planting activities.
+- Assign garden stewardship roles (rotating weekly).
+- Introduce observation and documentation practices.
+- First formative assessments.
+
+**Week 5-8: Full Curriculum Engagement**
+- Implement full lesson sequences aligned with the 5Rs.
+- Integrate academic content with garden activities.
+- Begin portfolio collection.
+- Conduct first peer observation cycle among pilot teachers.

--- a/12-implementation/part-3.md
+++ b/12-implementation/part-3.md
@@ -1,3 +1,85 @@
-# Implementation Guide Part 3
+# Implementation Guide Part 3: Quarter 3 — Expansion and Deepening Practice
 
-Content for part 3 of the implementation guide.
+## Quarter 3 (Months 10-18): Scaling From Pilot to Program
+
+### Analyzing Pilot Data
+
+Before expanding, conduct a thorough review of pilot outcomes:
+
+#### Data Review Protocol
+1. **Compile quantitative data**: Attendance, behavioral referrals, academic grades, and standardized assessment scores for pilot students compared to baseline and comparison groups.
+2. **Gather qualitative data**: Teacher reflections, student journal excerpts, family feedback surveys, observation notes.
+3. **Identify patterns**: Where did the curriculum have the strongest impact? Where were the challenges?
+4. **Document adaptations**: What modifications did pilot teachers make, and why?
+
+#### Key Questions for the Review
+- Did students demonstrate growth in SEL competencies as measured by selected instruments?
+- Were there measurable changes in attendance or behavioral data for pilot participants?
+- How did teachers rate their own confidence in trauma-informed garden instruction?
+- What did families observe at home?
+- Were there unexpected benefits or challenges?
+
+### Planning the Expansion
+
+Based on pilot findings, develop a plan to expand to additional classrooms and grade bands.
+
+#### Expansion Models
+
+**Model A: Grade Band Expansion**
+- Add one new grade band per semester.
+- Each new grade band begins with the pilot sequence (PD, then launch).
+- Experienced pilot teachers serve as mentors for new adopters.
+
+**Model B: School-Wide Adoption**
+- All grade bands launch simultaneously.
+- Requires more intensive PD and support infrastructure.
+- Best suited for smaller schools with strong administrative support.
+
+**Model C: District Scaling**
+- Pilot school becomes a demonstration site.
+- New schools send teams for observation and PD.
+- District provides centralized coordination, materials, and coaching.
+
+### Deepening Curriculum Integration
+
+As the program moves beyond the pilot phase, deepen integration with existing school structures:
+
+#### Academic Standards Alignment
+- Map all FG2G lessons to state standards (ELA, Math, Science, Social Studies).
+- Document alignment for administrator and school board review.
+- Create crosswalk documents showing how garden activities meet multiple standards simultaneously.
+
+#### Schedule Integration
+- Work with administrators to secure dedicated garden time in the master schedule.
+- Coordinate with specials (art, music, PE) for cross-curricular garden projects.
+- Plan seasonal garden events that align with the school calendar.
+
+#### Special Education and Intervention Integration
+- Train special education staff in FG2G approaches.
+- Develop modified garden activities for students with physical disabilities.
+- Create sensory profiles for the garden space (quiet zones, high-activity zones).
+- Integrate garden-based goals into IEPs where appropriate.
+
+### Building Internal Capacity
+
+#### Developing Teacher Leaders
+- Identify 1-2 educators per school to serve as FG2G instructional leaders.
+- Provide advanced training: coaching skills, adult learning theory, curriculum design.
+- Compensate teacher leaders with stipends or reduced non-garden duties.
+- Establish peer observation protocols led by teacher leaders.
+
+#### Creating Institutional Knowledge
+- Develop a school-specific FG2G handbook documenting local adaptations.
+- Record video examples of exemplary garden lessons for the PD library.
+- Maintain a shared digital resource bank (lesson plans, assessments, photos, data).
+- Archive student work samples that demonstrate growth over time.
+
+### Community Partnership Development
+
+Deepen existing partnerships and cultivate new ones:
+
+- **University partnerships**: Connect with education, horticulture, and public health programs for student teachers, research collaboration, and expertise.
+- **Extension services**: Leverage county extension agents for soil testing, pest management, and master gardener volunteers.
+- **Local businesses**: Engage garden centers, farms, and restaurants for material donations, field trips, and mentorship.
+- **Health organizations**: Partner with hospitals, mental health agencies, and pediatric practices that serve the same families.
+- **Cultural organizations**: Collaborate with community groups to ensure garden design and crop selection reflect the cultural heritage of students and families.

--- a/12-implementation/part-4.md
+++ b/12-implementation/part-4.md
@@ -1,3 +1,67 @@
-# Implementation Guide Part 4
+# Implementation Guide Part 4: Quarter 4 — Legacy and Future Vision
 
-Content for part 4 of the implementation guide.
+## Quarter 4 (Months 19-24): Establishing Sustainability and Legacy
+
+### Institutionalizing the Program
+
+By the end of Year 2, the FG2G program should transition from a project to an institutional commitment. This requires embedding the program into the permanent structures of the school or district.
+
+#### Policy and Governance
+- **Board adoption**: Present outcome data to the school board and seek formal adoption of FG2G as a recognized program (not a pilot or grant-funded initiative).
+- **Budget line items**: Transition funding from grants and donations to recurring budget allocations.
+- **Position descriptions**: Include garden-based, trauma-informed instruction in relevant job postings and evaluation criteria.
+- **Scheduling policy**: Codify dedicated garden instruction time in the master schedule template.
+
+#### Curriculum Formalization
+- **Scope and sequence approval**: Submit finalized scope and sequence through the district's curriculum adoption process.
+- **Materials list**: Establish an approved materials list for annual procurement.
+- **Assessment alignment**: Integrate FG2G assessments into the school's assessment calendar.
+- **Report card integration**: Where possible, include garden-based learning indicators in progress reports.
+
+### Building the Legacy Garden
+
+By Month 20, begin planning legacy elements that signal the program's permanence:
+
+- **Perennial installations**: Plant fruit trees, berry bushes, herb gardens, and native pollinator beds that will mature over years.
+- **Permanent structures**: Install raised beds with durable materials (stone, metal, composite lumber), arbors, seating areas, and outdoor classroom spaces.
+- **Student-designed elements**: Commission student artwork — mosaics, painted signs, sculptures — that personalize the garden.
+- **Commemorative features**: Dedicate garden sections to graduating classes, community donors, or school values.
+- **Accessibility upgrades**: Ensure all garden areas meet ADA standards with paved pathways, raised beds at wheelchair height, and sensory-accessible plantings.
+
+### Student Leadership Development
+
+Transition student roles from participants to leaders:
+
+#### Garden Leadership Council (Grades 6-12)
+- Student-led governance body for garden decisions.
+- Members propose and manage garden projects.
+- Council presents at school board meetings and community events.
+- Peer mentorship: older students teach younger students garden skills.
+
+#### Junior Master Gardener Program (Grades 3-5)
+- Structured skill-building sequence aligned with Junior Master Gardener or similar certification.
+- Students earn badges or certificates for demonstrated competencies.
+- Graduates serve as garden helpers for K-2 classrooms.
+
+#### Garden Ambassadors (All Grades)
+- Students lead garden tours for visitors, families, and community members.
+- Create and maintain garden documentation (photos, blog posts, social media with appropriate supervision).
+- Represent the school at community events and conferences.
+
+### Year 2 Summative Evaluation
+
+Conduct a comprehensive program evaluation at the 24-month mark:
+
+#### Evaluation Components
+1. **Student outcome analysis**: Compare academic, behavioral, and SEL data across 2 years.
+2. **Teacher effectiveness survey**: Assess educator confidence, satisfaction, and instructional quality.
+3. **Family engagement metrics**: Track volunteer hours, event attendance, and family survey results.
+4. **Community partnership audit**: Review partnership agreements, contributions, and mutual benefits.
+5. **Cost-benefit analysis**: Calculate per-student program costs relative to outcomes.
+6. **Fidelity assessment**: Measure adherence to the FG2G curriculum model and the 5Rs framework.
+
+#### Using Evaluation Results
+- Share findings with all stakeholders in an annual report.
+- Use data to refine curriculum, PD, and garden design for Year 3.
+- Submit findings for conference presentations or publication.
+- Inform district leadership about scaling decisions.

--- a/12-implementation/part-5.md
+++ b/12-implementation/part-5.md
@@ -1,3 +1,82 @@
-# Implementation Guide Part 5
+# Implementation Guide Part 5: Years 3-5 Long-Term Planning and District Scaling
 
-Content for part 5 of the implementation guide.
+## Long-Term Sustainability (Years 3-5)
+
+### Year 3: Maturation and Refinement
+
+By Year 3, the FG2G program should be operating as an established part of the school's identity. Focus shifts from building to refining.
+
+#### Curriculum Refinement Cycle
+- **Annual review**: Each spring, convene FG2G educators to review the curriculum against student data, teacher feedback, and updated standards.
+- **Lesson revision**: Update lessons that underperformed or no longer align with current best practices.
+- **New unit development**: Add units that respond to emerging student needs or community interests (e.g., food justice, climate science, entrepreneurship through farm stands).
+- **Cultural responsiveness audit**: Review garden crops, stories, and examples for cultural relevance to the current student population.
+
+#### Advanced Professional Development
+- **Trauma-informed coaching certification**: Support teacher leaders in earning coaching credentials.
+- **Garden educator certification**: Pursue formal credentials through organizations such as the American Horticultural Therapy Association or state extension programs.
+- **Conference participation**: Send FG2G educators to present at regional and national conferences.
+- **Action research**: Support teachers in conducting classroom-based research on garden education outcomes.
+
+#### Garden Evolution
+- Perennial plantings begin to mature, reducing annual replanting costs.
+- Students inherit and build upon previous classes' garden projects.
+- Expanded growing areas based on demonstrated success.
+- Introduction of advanced systems: composting programs, rain gardens, greenhouse or cold frame construction.
+
+### Year 4: District Scaling
+
+For districts ready to scale beyond the initial site(s), Year 4 focuses on replication.
+
+#### Developing a District FG2G Framework
+- **Central coordination**: Designate a district-level FG2G coordinator (part-time or full-time based on scale).
+- **Standardized core with local flexibility**: Establish non-negotiable program elements (5Rs framework, trauma-informed practice, garden integration) while allowing site-level adaptation.
+- **Resource sharing**: Create a district materials library (tools, curriculum kits, assessment templates) that schools can borrow.
+- **Centralized purchasing**: Negotiate bulk pricing for soil, seeds, tools, and infrastructure materials.
+
+#### New Site Launch Protocol
+For each new school joining the program:
+
+1. **Site assessment** (2 months): Evaluate garden space, staffing, and community context.
+2. **Leadership team formation** (1 month): Identify site coordinator, pilot teachers, and administrative champion.
+3. **Observation visits** (1 month): New teams visit established FG2G sites for full-day observations.
+4. **Foundation PD** (2 months): Deliver the core PD sequence (Modules 1-6 from Part 2).
+5. **Garden construction** (2-3 months): Build garden infrastructure with community volunteer days.
+6. **Mentored launch** (1 semester): New sites receive weekly coaching from experienced FG2G educators.
+7. **Independent operation** (semester 2+): Gradual release to site-level management with quarterly check-ins.
+
+#### Cross-Site Learning Network
+- Quarterly convenings of FG2G educators from all sites.
+- Shared data dashboard for comparing outcomes across schools.
+- Inter-school student projects (e.g., seed exchanges, joint harvest festivals).
+- District-wide FG2G showcase event each spring.
+
+### Year 5: Sustainability and Advocacy
+
+#### Financial Sustainability Model
+By Year 5, the program should operate on a diversified funding model:
+
+| Funding Source | Target Percentage | Strategy |
+|---|---|---|
+| District operating budget | 50-60% | Permanent budget allocation; positions funded through general fund |
+| Grants | 15-25% | Rotating grant portfolio; dedicated grant writer or shared position |
+| Community partnerships | 10-15% | In-kind donations, volunteer labor, material gifts |
+| Revenue generation | 5-10% | Farm stand sales, workshop fees, consulting to other districts |
+
+#### Policy Advocacy
+- Compile 5-year longitudinal outcome data.
+- Develop policy briefs for state legislators on the impact of garden-based, trauma-informed education.
+- Partner with state education agencies to include garden-based education in approved instructional models.
+- Advocate for state-level funding streams for school garden programs.
+
+#### Research and Publication
+- Partner with university researchers for formal program evaluation.
+- Submit findings to peer-reviewed journals in education, public health, and horticulture therapy.
+- Contribute to the evidence base for trauma-informed garden education.
+- Present at national conferences (AERA, NSTA, AHTA).
+
+#### Succession Planning
+- Document all institutional knowledge in a comprehensive program manual.
+- Cross-train multiple staff members in every critical role.
+- Develop a leadership pipeline: classroom teacher, teacher leader, site coordinator, district coordinator.
+- Establish an advisory board of community members, families, and alumni to provide continuity beyond individual staff tenure.

--- a/12-implementation/part-6.md
+++ b/12-implementation/part-6.md
@@ -1,3 +1,131 @@
-# Implementation Guide Part 6
+# Implementation Guide Part 6: Support Resources and Troubleshooting
 
-Content for part 6 of the implementation guide.
+## Support Resources
+
+### Funding and Grants
+
+#### Federal Funding Sources
+- **USDA Farm to School Grant Program**: Supports garden-based education, local food procurement, and farm to school activities. Grants range from $25,000 to $100,000.
+- **21st Century Community Learning Centers**: Funds before/after school programs that can include garden-based activities.
+- **Title I, Part A**: Schools with high percentages of low-income students can use Title I funds for programs that improve academic achievement, including garden-based instruction.
+- **Title IV, Part A (SSAE)**: Student Support and Academic Enrichment grants can fund well-rounded educational opportunities including environmental education.
+- **IDEA (Individuals with Disabilities Education Act)**: May fund garden modifications and therapeutic horticulture activities for students with IEPs.
+
+#### State and Regional Sources
+- State departments of agriculture often maintain school garden grant programs.
+- State education agency innovation grants.
+- Regional community foundations.
+- Environmental and conservation organization grants.
+
+#### Private Foundation Sources
+- Captain Planet Foundation: Funds school garden projects nationwide.
+- Whole Kids Foundation: Garden grant program for school edible gardens.
+- National Gardening Association: Youth Garden Grant program.
+- Local garden clubs and master gardener associations.
+
+#### Corporate Partnerships
+- Home improvement retailers (community garden programs).
+- Local nurseries and garden centers (material donations, expertise).
+- Health systems (wellness program sponsorship).
+- Technology companies (data collection and documentation tools).
+
+### Professional Organizations and Networks
+
+| Organization | Resource Type |
+|---|---|
+| American Horticultural Therapy Association (AHTA) | Certification, research, conference |
+| National Farm to School Network | Curriculum, policy advocacy, grant database |
+| Life Lab Science Program | Curriculum, teacher training |
+| Edible Schoolyard Project | Model program, PD, free curriculum resources |
+| National Wildlife Federation Schoolyard Habitats | Habitat certification, curriculum integration |
+| KidsGardening (National Gardening Association) | Grants, lesson plans, community of practice |
+| Collaborative for Academic, Social, and Emotional Learning (CASEL) | SEL frameworks, assessment tools, research |
+| National Child Traumatic Stress Network (NCTSN) | Trauma-informed practice resources, training |
+
+### Recommended Reading and Research
+
+#### Trauma-Informed Education
+- *Helping Traumatized Children Learn* — Massachusetts Advocates for Children
+- *Creating Trauma-Informed Schools* — Sporleder and Forbes
+- *The Body Keeps the Score* — Bessel van der Kolk
+- *Lost at School* — Ross Greene
+
+#### Garden-Based Education
+- *Digging Deeper: Integrating Youth Gardens into Schools and Communities* — Licy Do and Sam Denny
+- *The Growing Classroom* — Life Lab Science Program
+- *Junior Master Gardener Curriculum* — Texas A&M AgriLife Extension
+
+#### Therapeutic Horticulture
+- *Therapeutic Landscapes* — Clare Cooper Marcus and Naomi Sachs
+- *Horticulture as Therapy* — Sharon Simson and Martha Straus
+- *The Well-Gardened Mind* — Sue Stuart-Smith
+
+## Troubleshooting Common Challenges
+
+### Challenge: Educator Resistance
+
+**Symptoms**: Teachers express concerns about added workload, lack of confidence in garden skills, or skepticism about academic rigor.
+
+**Strategies**:
+- Start with willing volunteers; never mandate participation for initial cohorts.
+- Pair skeptical teachers with enthusiastic peer mentors for observation visits.
+- Share student outcome data from pilot classrooms.
+- Provide adequate planning time and reduce other demands during the pilot year.
+- Acknowledge that garden-based teaching is a skill that develops over time.
+
+### Challenge: Seasonal Limitations
+
+**Symptoms**: Garden activities are limited to spring and fall in cold climates; extreme heat restricts outdoor time in warm climates.
+
+**Strategies**:
+- Use indoor growing systems (grow lights, hydroponics, window gardens) during winter months.
+- Plant cold-hardy crops (kale, garlic, lettuce, radishes) to extend the growing season.
+- Use cold frames or low tunnels for season extension.
+- Schedule outdoor time for early morning or late afternoon in hot climates.
+- Develop indoor curriculum units (seed science, garden design, food preparation) for off-season months.
+
+### Challenge: Garden Vandalism or Neglect
+
+**Symptoms**: Garden is damaged during weekends, breaks, or summer; plants die from inconsistent care.
+
+**Strategies**:
+- Engage the broader community as garden stewards (community garden hours, family volunteer schedules).
+- Install basic security (fencing, motion-activated lighting).
+- Partner with summer programs or community organizations for summer maintenance.
+- Plant low-maintenance, drought-tolerant, or perennial crops that survive periods of neglect.
+- Automated drip irrigation with timers for consistent watering.
+
+### Challenge: Funding Gaps
+
+**Symptoms**: Grant funding ends; district budget cuts threaten the program.
+
+**Strategies**:
+- Diversify funding from Year 1 (never rely on a single source).
+- Build the program into the district operating budget as early as possible.
+- Document cost-effectiveness data (reduced behavioral interventions, improved attendance).
+- Develop revenue-generating activities (farm stand, seed sales, educator workshops).
+- Cultivate a "Friends of the Garden" community group for ongoing support.
+
+### Challenge: Student Behavioral Issues in the Garden
+
+**Symptoms**: Students are dysregulated, refuse to participate, or engage in unsafe behavior outdoors.
+
+**Strategies**:
+- Revisit and reinforce garden expectations regularly (the "Root" phase of the 5Rs).
+- Ensure the garden includes a designated quiet/regulation area.
+- Use pre-garden regulation check-ins (breathing exercises, body scans).
+- Offer choice within garden activities so students have agency.
+- Maintain low student-to-adult ratios during garden time.
+- Consult with school counselor for individual student support plans.
+
+### Challenge: Measuring Impact
+
+**Symptoms**: Difficulty demonstrating program value to administrators, school boards, or funders.
+
+**Strategies**:
+- Collect data from day one using the baseline measures described in Part 1.
+- Use both quantitative (test scores, attendance, referrals) and qualitative (student journals, teacher reflections, family surveys) data.
+- Document student growth through portfolio assessment.
+- Photograph and video document garden activities throughout the year (with appropriate consent).
+- Connect with university researchers for formal evaluation support.
+- Present data annually to stakeholders in accessible, visual formats.

--- a/13-conclusion/README.md
+++ b/13-conclusion/README.md
@@ -1,3 +1,68 @@
-# Conclusion
+# Conclusion: From Gardens to Growth — A Vision for Healing-Centered Education
 
-This section is under development.
+## The Seed We Plant Today
+
+Every garden begins with an act of faith — placing a seed in soil and trusting that, with the right conditions, something will grow. The From Garden to Growth (FG2G) curriculum is built on that same faith: the belief that every child, regardless of what they have experienced, carries within them an extraordinary capacity to heal, learn, and flourish.
+
+Throughout this curriculum, we have laid out a comprehensive framework for educators, administrators, and community partners who share this belief. From the theoretical foundations of trauma-informed pedagogy and therapeutic horticulture to the practical realities of garden design, lesson planning, and assessment, every element has been designed to serve one purpose: creating learning environments where healing and academic growth happen together, not in spite of each other, but because of each other.
+
+## What the 5Rs Make Possible
+
+The 5Rs Framework — **Root, Regulate, Reconnect, Restore, Reflect** — is more than a pedagogical model. It is a language for understanding what children need and a pathway for providing it:
+
+- **Root** reminds us that learning begins with identity and belonging. Before students can engage academically, they must feel grounded in who they are and where they are.
+- **Regulate** acknowledges that children affected by adverse experiences need explicit support in developing self-regulation. The garden provides a living laboratory for practicing these skills.
+- **Reconnect** recognizes that trauma disrupts relationships, and that healing happens in the context of safe, consistent connections with caring adults and peers.
+- **Restore** centers the idea that education can be restorative — that schools and gardens can become places where what has been harmed begins to mend.
+- **Reflect** cultivates the metacognitive skills that transform experience into understanding, helping students become authors of their own growth stories.
+
+These are not abstract principles. Across the grade bands — from kindergarteners planting their first seeds to high school students designing sustainable garden systems — the 5Rs translate into daily practices that make a measurable difference in children's lives.
+
+## A Call to Action
+
+This curriculum is an invitation. It is an invitation to:
+
+**Educators** — to step into the garden with your students and discover what becomes possible when learning is rooted in care, connection, and the natural world. You do not need to be a master gardener. You need only be willing to grow alongside the children you serve.
+
+**Administrators** — to invest in the infrastructure, professional development, and scheduling that make garden-based, trauma-informed education sustainable. The evidence is clear: when schools create healing-centered learning environments, attendance improves, behavioral incidents decrease, and academic outcomes rise.
+
+**Community Partners** — to bring your expertise, your resources, and your presence into school gardens. The partnerships described in this curriculum are not add-ons; they are essential to building the kind of wraparound support that children and families need.
+
+**Families** — to see the garden as a bridge between school and home. The skills children develop in the garden — patience, observation, nurturing, resilience — are skills that strengthen families and communities.
+
+**Policymakers** — to recognize that trauma-informed, garden-based education is not a luxury or an experiment. It is a research-supported approach to addressing the intersecting crises of childhood adversity, educational inequity, and disconnection from the natural world.
+
+## The Garden as Metaphor and Method
+
+We chose the garden as the centerpiece of this curriculum deliberately. Gardens teach what classrooms alone cannot:
+
+- That growth is not linear — plants grow in seasons, and so do children.
+- That setbacks are not failures — a late frost does not mean the garden is lost. It means we replant, adapt, and try again.
+- That care is reciprocal — when children tend a garden, the garden tends to them.
+- That diversity strengthens the whole — a polyculture garden is more resilient than a monoculture, just as a diverse classroom community is stronger than a homogeneous one.
+
+These are not just metaphors. They are lived experiences that reshape how children understand themselves and their capacity to affect the world around them.
+
+## Looking Forward
+
+The FG2G curriculum is a living document, designed to evolve as the communities that use it grow and change. The implementation guide in the preceding section provides the roadmap — from initial planning through long-term sustainability. But the real work happens in the hands of the people who bring this curriculum to life.
+
+We envision a future where:
+
+- Every school has access to a garden space designed for both learning and healing.
+- Trauma-informed practice is not a specialization but a baseline expectation for all educators.
+- Children who have experienced adversity are met with understanding, opportunity, and the tools to build their own resilience.
+- Communities rally around their schools and gardens as shared spaces for growth.
+- The evidence base for garden-based, trauma-informed education continues to deepen, informing policy and practice at every level.
+
+## A Final Reflection
+
+There is a moment in every garden season when you can see the first green shoots breaking through the soil. It is a quiet moment, easy to miss if you are not paying attention. But for anyone who has planted a seed and waited, it is extraordinary — proof that the conditions were right, that the care mattered, that growth was happening all along, even when it was invisible.
+
+The children in our schools are like those seeds. Many of them have been through experiences that no child should have to endure. Some of them are still underground, still gathering the strength to push through. Our job — as educators, as community members, as fellow human beings — is to tend the soil, provide the light, and trust in their capacity to grow.
+
+This curriculum gives you the tools. The garden gives you the space. The children will do the rest.
+
+---
+
+*"A garden is a grand teacher. It teaches patience and careful watchfulness; it teaches industry and thrift; above all it teaches entire trust."* — Gertrude Jekyll

--- a/docs/docs/10-implementation-guide/part-1.md
+++ b/docs/docs/10-implementation-guide/part-1.md
@@ -1,3 +1,100 @@
-# Implementation Guide Part 1
+# Implementation Guide Part 1: Readiness Assessment and Initial Planning
 
-Content for part 1 of the implementation guide.
+## Overview
+
+Successful implementation of the FG2G curriculum begins well before the first seed is planted. This section guides schools and districts through the readiness assessment, stakeholder engagement, and foundational planning needed to launch a garden-based, trauma-informed learning program.
+
+## Phase 1: Readiness Assessment (Months 1-3)
+
+### Organizational Capacity Review
+
+Before committing to implementation, conduct an honest assessment of your school or district's current capacity:
+
+#### Staffing and Expertise
+- **Educator readiness**: How many staff members have training in trauma-informed practices? In garden-based education?
+- **Administrative support**: Is there a designated administrator who will champion the program?
+- **Support staff**: Are counselors, social workers, and special educators prepared to integrate garden-based approaches?
+- **Maintenance**: Who will maintain garden spaces during breaks and summer months?
+
+#### Physical Resources
+- **Available land**: Identify potential garden sites — rooftops, courtyards, unused fields, raised bed areas, or indoor growing spaces.
+- **Water access**: Confirm proximity to water sources for irrigation.
+- **Sunlight**: Assess sun exposure across seasons (minimum 6 hours daily for most food crops).
+- **Soil quality**: Conduct soil testing for contaminants, especially in urban settings, before any planting.
+- **Tool storage**: Identify or plan secure storage for garden tools and supplies.
+
+#### Financial Resources
+- **Startup costs**: Estimate initial investment for garden construction, soil, tools, seeds, and infrastructure.
+- **Ongoing costs**: Project annual maintenance, replacement supplies, and professional development expenses.
+- **Funding sources**: Identify grants, district allocations, community donations, and parent organization support.
+
+### Stakeholder Mapping and Engagement
+
+Identify and engage key stakeholders early:
+
+| Stakeholder Group | Role in Implementation | Engagement Strategy |
+|---|---|---|
+| Teachers | Primary curriculum deliverers | Professional development, planning time, input on design |
+| Administrators | Resource allocation, scheduling | Regular briefings, data on outcomes, site visits to model programs |
+| Students | Learners and garden stewards | Voice and choice in garden design, leadership roles |
+| Families | Home-garden connection, volunteers | Information sessions, family garden events, take-home activities |
+| School counselors | Trauma-informed practice support | Co-planning, integration with existing SEL programs |
+| Custodial staff | Facility and grounds coordination | Early consultation on logistics, maintenance planning |
+| Community partners | Expertise, resources, mentorship | Partnership agreements, shared goals, clear roles |
+| School board | Policy and budget approval | Presentations with evidence base, pilot proposals |
+
+### Baseline Data Collection
+
+Gather baseline data to measure impact later:
+
+- **Academic metrics**: Standardized test scores, grades, course completion rates for target populations.
+- **Behavioral data**: Office referrals, suspensions, attendance rates.
+- **Social-emotional measures**: SEL survey data, school climate surveys.
+- **Health indicators**: If available, physical activity levels, nutrition knowledge.
+- **Teacher well-being**: Staff satisfaction surveys, retention rates.
+
+## Phase 2: Design and Planning (Months 3-6)
+
+### Forming the Implementation Team
+
+Establish a core team of 5-8 members:
+
+- **Program coordinator** (lead): Manages timeline, communication, and logistics.
+- **Lead educator(s)**: 2-3 teachers who will pilot the curriculum.
+- **Administrator**: Ensures scheduling, budgeting, and policy alignment.
+- **Counselor/social worker**: Guides trauma-informed practice integration.
+- **Community partner representative**: Connects to external resources and expertise.
+- **Parent/family representative**: Ensures family voice in planning.
+- **Student representative** (grades 6-12): Provides youth perspective.
+
+### Developing the Implementation Timeline
+
+Create a realistic timeline aligned with the school calendar:
+
+| Month | Milestone |
+|---|---|
+| 1-3 | Readiness assessment complete; stakeholders engaged |
+| 3-6 | Garden site designed; curriculum scope and sequence drafted; PD plan created |
+| 6-9 | Garden construction; initial professional development; materials procured |
+| 9-12 | Pilot launch with 2-3 classrooms; formative assessment begins |
+| 12-18 | Expand to additional classrooms based on pilot data; refine curriculum |
+| 18-24 | Full implementation across target grade bands; summative assessment |
+
+### Budget Planning
+
+#### Startup Budget Categories
+
+- **Garden infrastructure**: Raised beds, soil, irrigation, fencing, pathways, accessible design elements.
+- **Tools and supplies**: Hand tools (child-sized for K-2), wheelbarrows, watering cans, harvest baskets.
+- **Seeds and plants**: Culturally relevant varieties, perennials for long-term gardens, cover crops.
+- **Curriculum materials**: Print resources, assessment tools, student journals.
+- **Professional development**: Trainer fees, substitute coverage, stipends for planning time.
+- **Technology**: Data collection tools, documentation equipment.
+
+#### Sustainability Planning
+
+Budget for sustainability from day one:
+- Annual soil amendment and seed costs.
+- Tool replacement on a 3-year cycle.
+- Ongoing professional development for new staff.
+- Program evaluation costs.

--- a/docs/docs/10-implementation-guide/part-2.md
+++ b/docs/docs/10-implementation-guide/part-2.md
@@ -1,3 +1,119 @@
-# Implementation Guide Part 2
+# Implementation Guide Part 2: Professional Development and Pilot Launch
 
-Content for part 2 of the implementation guide.
+## Quarter 1 (Months 1-6): Building Educator Capacity
+
+### Professional Development Sequence
+
+Effective FG2G implementation requires educators who are confident in both trauma-informed practice and garden-based instruction. The professional development sequence should be completed before the pilot launch.
+
+#### Foundation Training (Months 1-2)
+
+**Module 1: Understanding ACEs and Trauma-Informed Education** (8 hours)
+- Prevalence and impact of adverse childhood experiences.
+- How trauma affects learning, behavior, and brain development.
+- Shifting from "What's wrong with you?" to "What happened to you?"
+- School-wide trauma-informed practices vs. individual interventions.
+
+**Module 2: The 5Rs Framework in Practice** (8 hours)
+- Deep dive into Root, Regulate, Reconnect, Restore, and Reflect.
+- Identifying 5Rs opportunities in daily instruction.
+- Regulation strategies for the garden and classroom.
+- Adapting the 5Rs across grade bands.
+
+**Module 3: Garden-Based Education Fundamentals** (8 hours)
+- Principles of therapeutic horticulture.
+- Academic integration through garden activities.
+- Seasonal planning for school gardens.
+- Safety protocols and risk management.
+
+#### Applied Training (Months 3-4)
+
+**Module 4: Curriculum Integration Workshop** (6 hours)
+- Mapping FG2G lessons to existing standards and pacing guides.
+- Co-planning garden-based units with grade-level teams.
+- Differentiation strategies for diverse learners.
+- IEP and 504 accommodation planning for garden activities.
+
+**Module 5: Assessment in the Garden** (4 hours)
+- Portfolio-based assessment design.
+- Rubric development for garden projects.
+- Observational assessment techniques.
+- Integrating SEL measurement with academic assessment.
+
+**Module 6: Practicum** (ongoing, Months 4-6)
+- Supervised garden sessions with students.
+- Peer observation and feedback cycles.
+- Reflective journaling on practice.
+- Mentorship from experienced garden educators.
+
+### Coaching and Mentorship Model
+
+Pair each pilot educator with:
+- **An instructional coach** who understands trauma-informed pedagogy.
+- **A garden mentor** — a master gardener, extension agent, or experienced garden educator.
+- **A peer partner** — another pilot educator for mutual support and accountability.
+
+### Creating a Professional Learning Community
+
+Establish a monthly PLC for FG2G educators:
+- Share successes and challenges from garden instruction.
+- Review student work and assessment data collaboratively.
+- Refine lessons based on classroom experience.
+- Build collective expertise and institutional knowledge.
+
+## Quarter 2 (Months 7-9): Pilot Launch
+
+### Selecting Pilot Classrooms
+
+Choose 2-3 classrooms for the initial pilot based on:
+- **Teacher readiness**: Educators who have completed PD and express enthusiasm.
+- **Student need**: Classrooms serving students who may benefit most from trauma-informed, experiential approaches.
+- **Grade band representation**: Include at least two grade bands to test curriculum across developmental levels.
+- **Logistical feasibility**: Proximity to garden space, scheduling flexibility.
+
+### Pilot Launch Checklist
+
+#### Garden Space
+- [ ] Garden beds constructed and filled with tested, clean soil.
+- [ ] Irrigation system installed and tested.
+- [ ] Pathways are accessible (ADA compliant).
+- [ ] Tool storage is secure, organized, and labeled.
+- [ ] Safety signage posted (sunscreen reminders, hand-washing, tool handling).
+- [ ] Sensory-friendly quiet area established within or adjacent to garden.
+
+#### Curriculum
+- [ ] Scope and sequence finalized for pilot grade bands.
+- [ ] Lesson plans reviewed and adapted for local context.
+- [ ] Student journals and materials printed or assembled.
+- [ ] Assessment tools (rubrics, portfolio templates, observation forms) prepared.
+
+#### Communication
+- [ ] Families informed via letter, meeting, or digital communication.
+- [ ] Permission forms collected for outdoor activities.
+- [ ] Allergy and medical information reviewed for all participating students.
+- [ ] Schedule communicated to all affected staff (specials, lunch, recess).
+
+#### Data Collection
+- [ ] Baseline assessments administered.
+- [ ] Data collection protocols established.
+- [ ] IRB approval obtained if conducting formal research.
+
+### First Weeks of Implementation
+
+**Week 1-2: Establishing the Garden as a Learning Space**
+- Introduce garden expectations and routines (the "Root" phase).
+- Practice transitions between classroom and garden.
+- Teach and practice regulation strategies for the outdoor space.
+- Begin garden journals.
+
+**Week 3-4: Building Community**
+- Collaborative planting activities.
+- Assign garden stewardship roles (rotating weekly).
+- Introduce observation and documentation practices.
+- First formative assessments.
+
+**Week 5-8: Full Curriculum Engagement**
+- Implement full lesson sequences aligned with the 5Rs.
+- Integrate academic content with garden activities.
+- Begin portfolio collection.
+- Conduct first peer observation cycle among pilot teachers.

--- a/docs/docs/10-implementation-guide/part-3.md
+++ b/docs/docs/10-implementation-guide/part-3.md
@@ -1,3 +1,85 @@
-# Implementation Guide Part 3
+# Implementation Guide Part 3: Quarter 3 — Expansion and Deepening Practice
 
-Content for part 3 of the implementation guide.
+## Quarter 3 (Months 10-18): Scaling From Pilot to Program
+
+### Analyzing Pilot Data
+
+Before expanding, conduct a thorough review of pilot outcomes:
+
+#### Data Review Protocol
+1. **Compile quantitative data**: Attendance, behavioral referrals, academic grades, and standardized assessment scores for pilot students compared to baseline and comparison groups.
+2. **Gather qualitative data**: Teacher reflections, student journal excerpts, family feedback surveys, observation notes.
+3. **Identify patterns**: Where did the curriculum have the strongest impact? Where were the challenges?
+4. **Document adaptations**: What modifications did pilot teachers make, and why?
+
+#### Key Questions for the Review
+- Did students demonstrate growth in SEL competencies as measured by selected instruments?
+- Were there measurable changes in attendance or behavioral data for pilot participants?
+- How did teachers rate their own confidence in trauma-informed garden instruction?
+- What did families observe at home?
+- Were there unexpected benefits or challenges?
+
+### Planning the Expansion
+
+Based on pilot findings, develop a plan to expand to additional classrooms and grade bands.
+
+#### Expansion Models
+
+**Model A: Grade Band Expansion**
+- Add one new grade band per semester.
+- Each new grade band begins with the pilot sequence (PD, then launch).
+- Experienced pilot teachers serve as mentors for new adopters.
+
+**Model B: School-Wide Adoption**
+- All grade bands launch simultaneously.
+- Requires more intensive PD and support infrastructure.
+- Best suited for smaller schools with strong administrative support.
+
+**Model C: District Scaling**
+- Pilot school becomes a demonstration site.
+- New schools send teams for observation and PD.
+- District provides centralized coordination, materials, and coaching.
+
+### Deepening Curriculum Integration
+
+As the program moves beyond the pilot phase, deepen integration with existing school structures:
+
+#### Academic Standards Alignment
+- Map all FG2G lessons to state standards (ELA, Math, Science, Social Studies).
+- Document alignment for administrator and school board review.
+- Create crosswalk documents showing how garden activities meet multiple standards simultaneously.
+
+#### Schedule Integration
+- Work with administrators to secure dedicated garden time in the master schedule.
+- Coordinate with specials (art, music, PE) for cross-curricular garden projects.
+- Plan seasonal garden events that align with the school calendar.
+
+#### Special Education and Intervention Integration
+- Train special education staff in FG2G approaches.
+- Develop modified garden activities for students with physical disabilities.
+- Create sensory profiles for the garden space (quiet zones, high-activity zones).
+- Integrate garden-based goals into IEPs where appropriate.
+
+### Building Internal Capacity
+
+#### Developing Teacher Leaders
+- Identify 1-2 educators per school to serve as FG2G instructional leaders.
+- Provide advanced training: coaching skills, adult learning theory, curriculum design.
+- Compensate teacher leaders with stipends or reduced non-garden duties.
+- Establish peer observation protocols led by teacher leaders.
+
+#### Creating Institutional Knowledge
+- Develop a school-specific FG2G handbook documenting local adaptations.
+- Record video examples of exemplary garden lessons for the PD library.
+- Maintain a shared digital resource bank (lesson plans, assessments, photos, data).
+- Archive student work samples that demonstrate growth over time.
+
+### Community Partnership Development
+
+Deepen existing partnerships and cultivate new ones:
+
+- **University partnerships**: Connect with education, horticulture, and public health programs for student teachers, research collaboration, and expertise.
+- **Extension services**: Leverage county extension agents for soil testing, pest management, and master gardener volunteers.
+- **Local businesses**: Engage garden centers, farms, and restaurants for material donations, field trips, and mentorship.
+- **Health organizations**: Partner with hospitals, mental health agencies, and pediatric practices that serve the same families.
+- **Cultural organizations**: Collaborate with community groups to ensure garden design and crop selection reflect the cultural heritage of students and families.

--- a/docs/docs/10-implementation-guide/part-4.md
+++ b/docs/docs/10-implementation-guide/part-4.md
@@ -1,3 +1,67 @@
-# Implementation Guide Part 4
+# Implementation Guide Part 4: Quarter 4 — Legacy and Future Vision
 
-Content for part 4 of the implementation guide.
+## Quarter 4 (Months 19-24): Establishing Sustainability and Legacy
+
+### Institutionalizing the Program
+
+By the end of Year 2, the FG2G program should transition from a project to an institutional commitment. This requires embedding the program into the permanent structures of the school or district.
+
+#### Policy and Governance
+- **Board adoption**: Present outcome data to the school board and seek formal adoption of FG2G as a recognized program (not a pilot or grant-funded initiative).
+- **Budget line items**: Transition funding from grants and donations to recurring budget allocations.
+- **Position descriptions**: Include garden-based, trauma-informed instruction in relevant job postings and evaluation criteria.
+- **Scheduling policy**: Codify dedicated garden instruction time in the master schedule template.
+
+#### Curriculum Formalization
+- **Scope and sequence approval**: Submit finalized scope and sequence through the district's curriculum adoption process.
+- **Materials list**: Establish an approved materials list for annual procurement.
+- **Assessment alignment**: Integrate FG2G assessments into the school's assessment calendar.
+- **Report card integration**: Where possible, include garden-based learning indicators in progress reports.
+
+### Building the Legacy Garden
+
+By Month 20, begin planning legacy elements that signal the program's permanence:
+
+- **Perennial installations**: Plant fruit trees, berry bushes, herb gardens, and native pollinator beds that will mature over years.
+- **Permanent structures**: Install raised beds with durable materials (stone, metal, composite lumber), arbors, seating areas, and outdoor classroom spaces.
+- **Student-designed elements**: Commission student artwork — mosaics, painted signs, sculptures — that personalize the garden.
+- **Commemorative features**: Dedicate garden sections to graduating classes, community donors, or school values.
+- **Accessibility upgrades**: Ensure all garden areas meet ADA standards with paved pathways, raised beds at wheelchair height, and sensory-accessible plantings.
+
+### Student Leadership Development
+
+Transition student roles from participants to leaders:
+
+#### Garden Leadership Council (Grades 6-12)
+- Student-led governance body for garden decisions.
+- Members propose and manage garden projects.
+- Council presents at school board meetings and community events.
+- Peer mentorship: older students teach younger students garden skills.
+
+#### Junior Master Gardener Program (Grades 3-5)
+- Structured skill-building sequence aligned with Junior Master Gardener or similar certification.
+- Students earn badges or certificates for demonstrated competencies.
+- Graduates serve as garden helpers for K-2 classrooms.
+
+#### Garden Ambassadors (All Grades)
+- Students lead garden tours for visitors, families, and community members.
+- Create and maintain garden documentation (photos, blog posts, social media with appropriate supervision).
+- Represent the school at community events and conferences.
+
+### Year 2 Summative Evaluation
+
+Conduct a comprehensive program evaluation at the 24-month mark:
+
+#### Evaluation Components
+1. **Student outcome analysis**: Compare academic, behavioral, and SEL data across 2 years.
+2. **Teacher effectiveness survey**: Assess educator confidence, satisfaction, and instructional quality.
+3. **Family engagement metrics**: Track volunteer hours, event attendance, and family survey results.
+4. **Community partnership audit**: Review partnership agreements, contributions, and mutual benefits.
+5. **Cost-benefit analysis**: Calculate per-student program costs relative to outcomes.
+6. **Fidelity assessment**: Measure adherence to the FG2G curriculum model and the 5Rs framework.
+
+#### Using Evaluation Results
+- Share findings with all stakeholders in an annual report.
+- Use data to refine curriculum, PD, and garden design for Year 3.
+- Submit findings for conference presentations or publication.
+- Inform district leadership about scaling decisions.

--- a/docs/docs/10-implementation-guide/part-5.md
+++ b/docs/docs/10-implementation-guide/part-5.md
@@ -1,3 +1,82 @@
-# Implementation Guide Part 5
+# Implementation Guide Part 5: Years 3-5 Long-Term Planning and District Scaling
 
-Content for part 5 of the implementation guide.
+## Long-Term Sustainability (Years 3-5)
+
+### Year 3: Maturation and Refinement
+
+By Year 3, the FG2G program should be operating as an established part of the school's identity. Focus shifts from building to refining.
+
+#### Curriculum Refinement Cycle
+- **Annual review**: Each spring, convene FG2G educators to review the curriculum against student data, teacher feedback, and updated standards.
+- **Lesson revision**: Update lessons that underperformed or no longer align with current best practices.
+- **New unit development**: Add units that respond to emerging student needs or community interests (e.g., food justice, climate science, entrepreneurship through farm stands).
+- **Cultural responsiveness audit**: Review garden crops, stories, and examples for cultural relevance to the current student population.
+
+#### Advanced Professional Development
+- **Trauma-informed coaching certification**: Support teacher leaders in earning coaching credentials.
+- **Garden educator certification**: Pursue formal credentials through organizations such as the American Horticultural Therapy Association or state extension programs.
+- **Conference participation**: Send FG2G educators to present at regional and national conferences.
+- **Action research**: Support teachers in conducting classroom-based research on garden education outcomes.
+
+#### Garden Evolution
+- Perennial plantings begin to mature, reducing annual replanting costs.
+- Students inherit and build upon previous classes' garden projects.
+- Expanded growing areas based on demonstrated success.
+- Introduction of advanced systems: composting programs, rain gardens, greenhouse or cold frame construction.
+
+### Year 4: District Scaling
+
+For districts ready to scale beyond the initial site(s), Year 4 focuses on replication.
+
+#### Developing a District FG2G Framework
+- **Central coordination**: Designate a district-level FG2G coordinator (part-time or full-time based on scale).
+- **Standardized core with local flexibility**: Establish non-negotiable program elements (5Rs framework, trauma-informed practice, garden integration) while allowing site-level adaptation.
+- **Resource sharing**: Create a district materials library (tools, curriculum kits, assessment templates) that schools can borrow.
+- **Centralized purchasing**: Negotiate bulk pricing for soil, seeds, tools, and infrastructure materials.
+
+#### New Site Launch Protocol
+For each new school joining the program:
+
+1. **Site assessment** (2 months): Evaluate garden space, staffing, and community context.
+2. **Leadership team formation** (1 month): Identify site coordinator, pilot teachers, and administrative champion.
+3. **Observation visits** (1 month): New teams visit established FG2G sites for full-day observations.
+4. **Foundation PD** (2 months): Deliver the core PD sequence (Modules 1-6 from Part 2).
+5. **Garden construction** (2-3 months): Build garden infrastructure with community volunteer days.
+6. **Mentored launch** (1 semester): New sites receive weekly coaching from experienced FG2G educators.
+7. **Independent operation** (semester 2+): Gradual release to site-level management with quarterly check-ins.
+
+#### Cross-Site Learning Network
+- Quarterly convenings of FG2G educators from all sites.
+- Shared data dashboard for comparing outcomes across schools.
+- Inter-school student projects (e.g., seed exchanges, joint harvest festivals).
+- District-wide FG2G showcase event each spring.
+
+### Year 5: Sustainability and Advocacy
+
+#### Financial Sustainability Model
+By Year 5, the program should operate on a diversified funding model:
+
+| Funding Source | Target Percentage | Strategy |
+|---|---|---|
+| District operating budget | 50-60% | Permanent budget allocation; positions funded through general fund |
+| Grants | 15-25% | Rotating grant portfolio; dedicated grant writer or shared position |
+| Community partnerships | 10-15% | In-kind donations, volunteer labor, material gifts |
+| Revenue generation | 5-10% | Farm stand sales, workshop fees, consulting to other districts |
+
+#### Policy Advocacy
+- Compile 5-year longitudinal outcome data.
+- Develop policy briefs for state legislators on the impact of garden-based, trauma-informed education.
+- Partner with state education agencies to include garden-based education in approved instructional models.
+- Advocate for state-level funding streams for school garden programs.
+
+#### Research and Publication
+- Partner with university researchers for formal program evaluation.
+- Submit findings to peer-reviewed journals in education, public health, and horticulture therapy.
+- Contribute to the evidence base for trauma-informed garden education.
+- Present at national conferences (AERA, NSTA, AHTA).
+
+#### Succession Planning
+- Document all institutional knowledge in a comprehensive program manual.
+- Cross-train multiple staff members in every critical role.
+- Develop a leadership pipeline: classroom teacher, teacher leader, site coordinator, district coordinator.
+- Establish an advisory board of community members, families, and alumni to provide continuity beyond individual staff tenure.

--- a/docs/docs/10-implementation-guide/part-6.md
+++ b/docs/docs/10-implementation-guide/part-6.md
@@ -1,3 +1,131 @@
-# Implementation Guide Part 6
+# Implementation Guide Part 6: Support Resources and Troubleshooting
 
-Content for part 6 of the implementation guide.
+## Support Resources
+
+### Funding and Grants
+
+#### Federal Funding Sources
+- **USDA Farm to School Grant Program**: Supports garden-based education, local food procurement, and farm to school activities. Grants range from $25,000 to $100,000.
+- **21st Century Community Learning Centers**: Funds before/after school programs that can include garden-based activities.
+- **Title I, Part A**: Schools with high percentages of low-income students can use Title I funds for programs that improve academic achievement, including garden-based instruction.
+- **Title IV, Part A (SSAE)**: Student Support and Academic Enrichment grants can fund well-rounded educational opportunities including environmental education.
+- **IDEA (Individuals with Disabilities Education Act)**: May fund garden modifications and therapeutic horticulture activities for students with IEPs.
+
+#### State and Regional Sources
+- State departments of agriculture often maintain school garden grant programs.
+- State education agency innovation grants.
+- Regional community foundations.
+- Environmental and conservation organization grants.
+
+#### Private Foundation Sources
+- Captain Planet Foundation: Funds school garden projects nationwide.
+- Whole Kids Foundation: Garden grant program for school edible gardens.
+- National Gardening Association: Youth Garden Grant program.
+- Local garden clubs and master gardener associations.
+
+#### Corporate Partnerships
+- Home improvement retailers (community garden programs).
+- Local nurseries and garden centers (material donations, expertise).
+- Health systems (wellness program sponsorship).
+- Technology companies (data collection and documentation tools).
+
+### Professional Organizations and Networks
+
+| Organization | Resource Type |
+|---|---|
+| American Horticultural Therapy Association (AHTA) | Certification, research, conference |
+| National Farm to School Network | Curriculum, policy advocacy, grant database |
+| Life Lab Science Program | Curriculum, teacher training |
+| Edible Schoolyard Project | Model program, PD, free curriculum resources |
+| National Wildlife Federation Schoolyard Habitats | Habitat certification, curriculum integration |
+| KidsGardening (National Gardening Association) | Grants, lesson plans, community of practice |
+| Collaborative for Academic, Social, and Emotional Learning (CASEL) | SEL frameworks, assessment tools, research |
+| National Child Traumatic Stress Network (NCTSN) | Trauma-informed practice resources, training |
+
+### Recommended Reading and Research
+
+#### Trauma-Informed Education
+- *Helping Traumatized Children Learn* — Massachusetts Advocates for Children
+- *Creating Trauma-Informed Schools* — Sporleder and Forbes
+- *The Body Keeps the Score* — Bessel van der Kolk
+- *Lost at School* — Ross Greene
+
+#### Garden-Based Education
+- *Digging Deeper: Integrating Youth Gardens into Schools and Communities* — Licy Do and Sam Denny
+- *The Growing Classroom* — Life Lab Science Program
+- *Junior Master Gardener Curriculum* — Texas A&M AgriLife Extension
+
+#### Therapeutic Horticulture
+- *Therapeutic Landscapes* — Clare Cooper Marcus and Naomi Sachs
+- *Horticulture as Therapy* — Sharon Simson and Martha Straus
+- *The Well-Gardened Mind* — Sue Stuart-Smith
+
+## Troubleshooting Common Challenges
+
+### Challenge: Educator Resistance
+
+**Symptoms**: Teachers express concerns about added workload, lack of confidence in garden skills, or skepticism about academic rigor.
+
+**Strategies**:
+- Start with willing volunteers; never mandate participation for initial cohorts.
+- Pair skeptical teachers with enthusiastic peer mentors for observation visits.
+- Share student outcome data from pilot classrooms.
+- Provide adequate planning time and reduce other demands during the pilot year.
+- Acknowledge that garden-based teaching is a skill that develops over time.
+
+### Challenge: Seasonal Limitations
+
+**Symptoms**: Garden activities are limited to spring and fall in cold climates; extreme heat restricts outdoor time in warm climates.
+
+**Strategies**:
+- Use indoor growing systems (grow lights, hydroponics, window gardens) during winter months.
+- Plant cold-hardy crops (kale, garlic, lettuce, radishes) to extend the growing season.
+- Use cold frames or low tunnels for season extension.
+- Schedule outdoor time for early morning or late afternoon in hot climates.
+- Develop indoor curriculum units (seed science, garden design, food preparation) for off-season months.
+
+### Challenge: Garden Vandalism or Neglect
+
+**Symptoms**: Garden is damaged during weekends, breaks, or summer; plants die from inconsistent care.
+
+**Strategies**:
+- Engage the broader community as garden stewards (community garden hours, family volunteer schedules).
+- Install basic security (fencing, motion-activated lighting).
+- Partner with summer programs or community organizations for summer maintenance.
+- Plant low-maintenance, drought-tolerant, or perennial crops that survive periods of neglect.
+- Automated drip irrigation with timers for consistent watering.
+
+### Challenge: Funding Gaps
+
+**Symptoms**: Grant funding ends; district budget cuts threaten the program.
+
+**Strategies**:
+- Diversify funding from Year 1 (never rely on a single source).
+- Build the program into the district operating budget as early as possible.
+- Document cost-effectiveness data (reduced behavioral interventions, improved attendance).
+- Develop revenue-generating activities (farm stand, seed sales, educator workshops).
+- Cultivate a "Friends of the Garden" community group for ongoing support.
+
+### Challenge: Student Behavioral Issues in the Garden
+
+**Symptoms**: Students are dysregulated, refuse to participate, or engage in unsafe behavior outdoors.
+
+**Strategies**:
+- Revisit and reinforce garden expectations regularly (the "Root" phase of the 5Rs).
+- Ensure the garden includes a designated quiet/regulation area.
+- Use pre-garden regulation check-ins (breathing exercises, body scans).
+- Offer choice within garden activities so students have agency.
+- Maintain low student-to-adult ratios during garden time.
+- Consult with school counselor for individual student support plans.
+
+### Challenge: Measuring Impact
+
+**Symptoms**: Difficulty demonstrating program value to administrators, school boards, or funders.
+
+**Strategies**:
+- Collect data from day one using the baseline measures described in Part 1.
+- Use both quantitative (test scores, attendance, referrals) and qualitative (student journals, teacher reflections, family surveys) data.
+- Document student growth through portfolio assessment.
+- Photograph and video document garden activities throughout the year (with appropriate consent).
+- Connect with university researchers for formal evaluation support.
+- Present data annually to stakeholders in accessible, visual formats.


### PR DESCRIPTION
…plementation guide

The 13-conclusion/README.md was a placeholder with no actual conclusion content (no vision statement, call to action, or closing narrative). The 12-implementation/ parts (1-6) were also empty stubs.

Changes:
- Replace 13-conclusion/README.md placeholder with a full conclusion including vision statement, 5Rs summary, call to action for stakeholders, garden metaphor narrative, forward-looking vision, and closing reflection
- Populate 12-implementation/ parts 1-6 with structured content: Part 1: Readiness assessment and initial planning (Months 1-6) Part 2: Professional development and pilot launch (Months 1-9) Part 3: Quarter 3 expansion and deepening practice (Months 10-18) Part 4: Quarter 4 legacy and future vision (Months 19-24) Part 5: Years 3-5 long-term planning and district scaling Part 6: Support resources and troubleshooting
- Sync docs/docs/10-implementation-guide/ with the updated content

https://claude.ai/code/session_01LgFsHM1YWPDYUuYZA4EVsf