### PR TITLE
docs: add Git history secrets scan verification report

### DIFF
--- a/docs/security-audit-secrets-scan.md
+++ b/docs/security-audit-secrets-scan.md
@@ -1,0 +1,53 @@
+# Git History Secrets Scan Report
+
+**Date:** 2026-02-08
+**Branch:** claude/verify-no-secrets-history-6EkST
+**Scope:** Full Git history (all branches, all commits)
+
+## Summary
+
+**Result: No real secrets found in Git history.**
+
+The repository was scanned for leaked credentials, API keys, tokens, private keys, and other sensitive material across the entire Git history.
+
+## Scan Methodology
+
+The following patterns were searched across all commits using `git log --all -p -S`:
+
+| Pattern | Result |
+|---------|--------|
+| AWS access keys (`AKIA*`) | None found |
+| OpenAI / Stripe live keys (`sk_live`, `pk_live`) | None found |
+| Anthropic API keys (`sk-ant-api*`) | None found |
+| GitHub / GitLab / Slack tokens (`ghp_`, `glpat-`, `xoxb-`) | None found |
+| PEM private keys (`BEGIN.*PRIVATE KEY`) | None found |
+| Private key files (`.pem`, `.key`, `.p12`, etc.) | None tracked |
+| JWT tokens (`eyJ...`) | None found |
+| `.env` / `.env.local` / `.env.production` files | None tracked (only `.env.example`) |
+| Hardcoded `DATABASE_URL` values | Only placeholder/example values |
+| Hardcoded `password` values | Only placeholder/example values |
+| Hardcoded `secret` values | See notes below |
+| Hardcoded `api_key` values | Only placeholder/example values |
+
+## Files Reviewed
+
+- `.env.example` -- Contains only placeholder values (`sk_test_xxxxx`, `pk_test_xxxxx`, `sk-ant-xxxxx`, `whsec_xxxxx`)
+- `.github/workflows/e2e-tests.yml` -- References `${{ secrets.* }}` GitHub Actions secrets with safe placeholder fallbacks
+- `docs/n8n-webhook-setup.md` -- Contains an example hex string illustrating `openssl rand -hex 32` output (documentation only, not a real secret)
+- `docs/ux-testing-plan.md` -- References `$N8N_WEBHOOK_SECRET` env var (not a hardcoded value)
+- `scripts/setup-rag-n8n.sh` -- References environment variables, does not hardcode secrets
+
+## .gitignore Coverage
+
+The `.gitignore` correctly excludes:
+- `.env` (actual environment file)
+- `.env*.local` (local overrides)
+- `*.pem` (certificate/key files)
+- `/node_modules`
+- `.vercel`
+
+## Recommendations
+
+1. **No remediation required** -- No real secrets were found in the Git history.
+2. **Continue using `.env.example`** with placeholder values for onboarding documentation.
+3. **Consider adding a pre-commit hook** (e.g., `detect-secrets` or `gitleaks`) to prevent accidental future commits of secrets.


### PR DESCRIPTION
Comprehensive scan of all branches and commits found no real secrets (API keys, tokens, passwords, private keys) in the repository history. Only placeholder/example values exist in .env.example and documentation.

https://claude.ai/code/session_01CqXYBe6mmiRMfMGmZKU68J