### PR TITLE
Add regulation detection and thinking quality analysis to chat API

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -6,6 +6,8 @@ import { buildMasterSystemPrompt } from '@/lib/ai/prompts/master-system-prompt';
 import { generateEmbedding } from '@/lib/pinecone/embeddings';
 import { queryPinecone } from '@/lib/pinecone/client';
 import { enforceUsageLimits, UsageLimitError } from '@/lib/usage-limits';
+import { detectDysregulation, updateRegulationLevel } from '@/lib/regulation/detector';
+import { analyzeThinkingQuality } from '@/lib/trace/tracker';
 import { z } from 'zod';
 
 const chatRequestSchema = z.object({

--- a/src/app/api/sessions/[sessionId]/route.ts
+++ b/src/app/api/sessions/[sessionId]/route.ts
@@ -14,7 +14,6 @@ const updateSessionSchema = z.object({
   metadata: z.record(z.unknown()).optional(),
   endSession: z.boolean().optional(),
   endedAt: z.string().optional(),
-  metadata: z.record(z.unknown()).optional(),
 });
 
 export async function GET(


### PR DESCRIPTION
## Summary
This PR enhances the chat API with new capabilities for detecting dysregulation and analyzing thinking quality, while also fixing a schema validation issue in the sessions endpoint.

## Key Changes
- **Chat API Enhancement**: Added imports for regulation detection and thinking quality analysis modules to enable monitoring of user state and response quality
  - `detectDysregulation` and `updateRegulationLevel` from the regulation detector module
  - `analyzeThinkingQuality` from the trace tracker module
- **Sessions Schema Fix**: Removed duplicate `metadata` field definition in the `updateSessionSchema` validation object that was causing schema conflicts

## Implementation Details
The new imports in the chat route suggest upcoming functionality to:
- Monitor and detect dysregulation patterns in user interactions
- Track and update regulation levels dynamically
- Analyze the quality of AI thinking/reasoning in responses

These modules are imported but not yet utilized in the route handler, indicating they will be integrated in follow-up commits or are being prepared for gradual rollout.

The duplicate field removal in the sessions schema is a bug fix that prevents validation errors when updating session metadata.

https://claude.ai/code/session_01Tx6DxRZWh94uM9hGsjJQj2