### PR TITLE
Add progress dashboard visualizations: mastery donut chart, growth tr…

### DIFF
--- a/src/app/progress/page.tsx
+++ b/src/app/progress/page.tsx
@@ -1,8 +1,10 @@
 import { auth } from '@clerk/nextjs/server';
 import { db } from '@/lib/db';
 import { ProgressSummary } from '@/components/progress/progress-summary';
+import { MasteryOverview } from '@/components/progress/mastery-overview';
 import { MasteryByStandard } from '@/components/progress/mastery-by-standard';
-import { SessionHistory } from '@/components/progress/session-history';
+import { GrowthChart } from '@/components/progress/growth-chart';
+import { SessionTimeline } from '@/components/progress/session-timeline';
 import { ReasoningMoveChart } from '@/components/progress/reasoning-move-chart';
 import { BloomsTaxonomy } from '@/components/progress/blooms-taxonomy';
 import { ExportButton } from '@/components/progress/export-button';
@@ -19,7 +21,7 @@ async function getProgressData() {
 
   const studentId = user.student.id;
 
-  const [progressEntries, reasoningMoves, recentSessions, assessments] = await Promise.all([
+  const [progressEntries, reasoningMoves, recentSessions, assessments, timedAssessments] = await Promise.all([
     db.progress.findMany({
       where: { studentId },
       include: { standard: true },
@@ -39,6 +41,17 @@ async function getProgressData() {
       where: { session: { studentId } },
       select: { bloomsLevel: true, isCorrect: true, score: true },
     }),
+    db.assessment.findMany({
+      where: { session: { studentId } },
+      select: {
+        score: true,
+        isCorrect: true,
+        bloomsLevel: true,
+        createdAt: true,
+        session: { select: { subject: true } },
+      },
+      orderBy: { createdAt: 'asc' },
+    }),
   ]);
 
   const totalStandards = progressEntries.length;
@@ -48,8 +61,25 @@ async function getProgressData() {
   const masteredCount = progressEntries.filter(p => p.masteryLevel >= 80).length;
   const inProgressCount = progressEntries.filter(p => p.masteryLevel > 0 && p.masteryLevel < 80).length;
 
+  // Compute streak: count consecutive days (going backwards) that have at least one session
+  const sessionDates = new Set(
+    recentSessions.map(s => new Date(s.startedAt).toISOString().slice(0, 10))
+  );
+  let streak = 0;
+  const today = new Date();
+  for (let i = 0; i < 365; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    if (sessionDates.has(key)) {
+      streak++;
+    } else if (i > 0) {
+      break;
+    }
+  }
+
   return {
-    summary: { totalStandards, averageMastery, masteredCount, inProgressCount, totalSessions: recentSessions.length },
+    summary: { totalStandards, averageMastery, masteredCount, inProgressCount, totalSessions: recentSessions.length, streak },
     standards: progressEntries.map(p => ({
       masteryLevel: p.masteryLevel,
       assessmentCount: p.assessmentCount,
@@ -74,6 +104,13 @@ async function getProgressData() {
       bloomsLevel: a.bloomsLevel,
       isCorrect: a.isCorrect,
       score: a.score,
+    })),
+    growthData: timedAssessments.map(a => ({
+      date: a.createdAt.toISOString(),
+      score: a.score,
+      isCorrect: a.isCorrect,
+      bloomsLevel: a.bloomsLevel,
+      subject: a.session.subject,
     })),
   };
 }
@@ -108,6 +145,12 @@ export default async function ProgressPage() {
         <ProgressSummary summary={data.summary} />
       </section>
 
+      {/* Mastery overview + Growth chart */}
+      <div className="mb-6 grid gap-6 lg:grid-cols-2">
+        <MasteryOverview standards={data.standards} />
+        <GrowthChart data={data.growthData} />
+      </div>
+
       {/* Two-column layout on desktop */}
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Left: Standards mastery + Bloom's */}
@@ -119,7 +162,7 @@ export default async function ProgressPage() {
         {/* Right: Reasoning moves + Sessions */}
         <div className="space-y-6">
           <ReasoningMoveChart moves={data.reasoningMoves} />
-          <SessionHistory sessions={data.recentSessions} />
+          <SessionTimeline sessions={data.recentSessions} />
         </div>
       </div>
 

--- a/src/components/progress/growth-chart.tsx
+++ b/src/components/progress/growth-chart.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+interface GrowthDataPoint {
+  date: string;
+  score: number | null;
+  isCorrect: boolean | null;
+  bloomsLevel: string;
+  subject: string;
+}
+
+const SUBJECT_COLORS: Record<string, string> = {
+  MATH: '#3B82F6',
+  SCIENCE: '#10B981',
+  LANGUAGE_ARTS: '#8B5CF6',
+};
+
+const SUBJECT_LABELS: Record<string, string> = {
+  MATH: 'Math',
+  SCIENCE: 'Science',
+  LANGUAGE_ARTS: 'ELA',
+};
+
+type TimeRange = '7d' | '30d' | '90d' | 'all';
+
+function getWeekKey(date: Date): string {
+  const d = new Date(date);
+  d.setDate(d.getDate() - d.getDay());
+  return d.toISOString().slice(0, 10);
+}
+
+function filterByRange(data: GrowthDataPoint[], range: TimeRange): GrowthDataPoint[] {
+  if (range === 'all') return data;
+  const now = Date.now();
+  const ms = { '7d': 7, '30d': 30, '90d': 90 }[range] * 86400000;
+  return data.filter((d) => now - new Date(d.date).getTime() <= ms);
+}
+
+interface WeekBucket {
+  weekKey: string;
+  label: string;
+  avgScore: number;
+  count: number;
+  correctRate: number;
+}
+
+function aggregateByWeek(data: GrowthDataPoint[]): WeekBucket[] {
+  const buckets = new Map<string, { scores: number[]; correct: number; total: number }>();
+
+  for (const d of data) {
+    const key = getWeekKey(new Date(d.date));
+    if (!buckets.has(key)) buckets.set(key, { scores: [], correct: 0, total: 0 });
+    const b = buckets.get(key)!;
+    if (d.score != null) b.scores.push(d.score);
+    b.total++;
+    if (d.isCorrect) b.correct++;
+  }
+
+  return Array.from(buckets.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([weekKey, b]) => ({
+      weekKey,
+      label: new Date(weekKey).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+      avgScore: b.scores.length > 0 ? b.scores.reduce((s, v) => s + v, 0) / b.scores.length : 0,
+      count: b.total,
+      correctRate: b.total > 0 ? b.correct / b.total : 0,
+    }));
+}
+
+// Chart rendering constants
+const CHART_W = 400;
+const CHART_H = 180;
+const PAD_L = 36;
+const PAD_R = 12;
+const PAD_T = 12;
+const PAD_B = 28;
+const PLOT_W = CHART_W - PAD_L - PAD_R;
+const PLOT_H = CHART_H - PAD_T - PAD_B;
+
+export function GrowthChart({ data }: { data: GrowthDataPoint[] }) {
+  const [range, setRange] = useState<TimeRange>('30d');
+
+  const filtered = useMemo(() => filterByRange(data, range), [data, range]);
+  const buckets = useMemo(() => aggregateByWeek(filtered), [filtered]);
+
+  if (data.length === 0) {
+    return (
+      <div className="rounded-xl border border-neutral-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-neutral-900">Growth Over Time</h2>
+        <p className="mt-3 text-sm text-neutral-500">
+          Complete assessments to see your growth trends here.
+        </p>
+      </div>
+    );
+  }
+
+  const maxScore = Math.max(...buckets.map((b) => b.avgScore), 1);
+  const yMax = Math.ceil(maxScore / 20) * 20 || 100;
+
+  function x(i: number) {
+    if (buckets.length <= 1) return PAD_L + PLOT_W / 2;
+    return PAD_L + (i / (buckets.length - 1)) * PLOT_W;
+  }
+  function y(val: number) {
+    return PAD_T + PLOT_H - (val / yMax) * PLOT_H;
+  }
+
+  // Build polyline points
+  const linePoints = buckets.map((b, i) => `${x(i)},${y(b.avgScore)}`).join(' ');
+
+  // Build area path (filled below the line)
+  const areaPath =
+    buckets.length > 0
+      ? `M${x(0)},${y(0)} ` +
+        buckets.map((b, i) => `L${x(i)},${y(b.avgScore)}`).join(' ') +
+        ` L${x(buckets.length - 1)},${y(0)} Z`
+      : '';
+
+  // Y-axis gridlines
+  const yTicks = [0, yMax * 0.25, yMax * 0.5, yMax * 0.75, yMax];
+
+  // Subject breakdown for this range
+  const subjectCounts: Record<string, number> = {};
+  for (const d of filtered) {
+    subjectCounts[d.subject] = (subjectCounts[d.subject] || 0) + 1;
+  }
+
+  const ranges: { key: TimeRange; label: string }[] = [
+    { key: '7d', label: '7d' },
+    { key: '30d', label: '30d' },
+    { key: '90d', label: '90d' },
+    { key: 'all', label: 'All' },
+  ];
+
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white p-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-neutral-900">Growth Over Time</h2>
+          <p className="mt-1 text-xs text-neutral-500">
+            Weekly average assessment scores
+          </p>
+        </div>
+        <div className="flex gap-1">
+          {ranges.map((r) => (
+            <button
+              key={r.key}
+              onClick={() => setRange(r.key)}
+              className={`rounded-md px-2 py-0.5 text-xs font-medium transition-colors ${
+                range === r.key
+                  ? 'bg-neutral-900 text-white'
+                  : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200'
+              }`}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {buckets.length === 0 ? (
+        <p className="mt-6 text-center text-sm text-neutral-400">
+          No data in this time range.
+        </p>
+      ) : (
+        <>
+          <svg
+            viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+            className="mt-4 w-full"
+            preserveAspectRatio="xMidYMid meet"
+          >
+            {/* Gridlines */}
+            {yTicks.map((tick) => (
+              <g key={tick}>
+                <line
+                  x1={PAD_L}
+                  y1={y(tick)}
+                  x2={CHART_W - PAD_R}
+                  y2={y(tick)}
+                  stroke="#e5e7eb"
+                  strokeWidth="0.5"
+                />
+                <text
+                  x={PAD_L - 4}
+                  y={y(tick) + 3}
+                  textAnchor="end"
+                  className="fill-neutral-400"
+                  fontSize="9"
+                >
+                  {Math.round(tick)}
+                </text>
+              </g>
+            ))}
+
+            {/* Area fill */}
+            <path d={areaPath} fill="url(#growthGradient)" opacity="0.3" />
+
+            {/* Line */}
+            <polyline
+              points={linePoints}
+              fill="none"
+              stroke="#22c55e"
+              strokeWidth="2"
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+
+            {/* Data points */}
+            {buckets.map((b, i) => (
+              <g key={b.weekKey}>
+                <circle cx={x(i)} cy={y(b.avgScore)} r="3.5" fill="#22c55e" />
+                <circle cx={x(i)} cy={y(b.avgScore)} r="2" fill="white" />
+              </g>
+            ))}
+
+            {/* X-axis labels (show a subset to avoid overlap) */}
+            {buckets.map((b, i) => {
+              const showEvery = Math.max(1, Math.ceil(buckets.length / 6));
+              if (i % showEvery !== 0 && i !== buckets.length - 1) return null;
+              return (
+                <text
+                  key={b.weekKey}
+                  x={x(i)}
+                  y={CHART_H - 4}
+                  textAnchor="middle"
+                  className="fill-neutral-400"
+                  fontSize="8"
+                >
+                  {b.label}
+                </text>
+              );
+            })}
+
+            {/* Gradient definition */}
+            <defs>
+              <linearGradient id="growthGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#22c55e" stopOpacity="0.4" />
+                <stop offset="100%" stopColor="#22c55e" stopOpacity="0.02" />
+              </linearGradient>
+            </defs>
+          </svg>
+
+          {/* Subject breakdown */}
+          <div className="mt-3 flex flex-wrap items-center gap-3 text-[11px] text-neutral-500">
+            <span>{filtered.length} assessments</span>
+            {Object.entries(subjectCounts).map(([subj, count]) => (
+              <span key={subj} className="flex items-center gap-1">
+                <span
+                  className="inline-block h-2 w-2 rounded-full"
+                  style={{ backgroundColor: SUBJECT_COLORS[subj] || '#6B7280' }}
+                />
+                {SUBJECT_LABELS[subj] || subj}: {count}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/progress/mastery-overview.tsx
+++ b/src/components/progress/mastery-overview.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+interface Standard {
+  masteryLevel: number;
+  assessmentCount: number;
+  standard: {
+    code: string;
+    subject: string;
+    description: string;
+  };
+}
+
+const TIERS = [
+  { label: 'Mastered', min: 80, color: '#22c55e' },
+  { label: 'Proficient', min: 60, color: '#3b82f6' },
+  { label: 'Developing', min: 40, color: '#f59e0b' },
+  { label: 'Beginning', min: 0, color: '#ef4444' },
+] as const;
+
+function classifyTier(mastery: number): (typeof TIERS)[number] {
+  for (const tier of TIERS) {
+    if (mastery >= tier.min) return tier;
+  }
+  return TIERS[TIERS.length - 1];
+}
+
+export function MasteryOverview({ standards }: { standards: Standard[] }) {
+  if (standards.length === 0) {
+    return (
+      <div className="rounded-xl border border-neutral-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-neutral-900">Mastery Overview</h2>
+        <p className="mt-3 text-sm text-neutral-500">
+          No standards tracked yet. Start a tutoring session to see your mastery breakdown.
+        </p>
+      </div>
+    );
+  }
+
+  // Count standards per tier
+  const tierCounts = TIERS.map((tier) => ({
+    ...tier,
+    count: standards.filter((s) => classifyTier(s.masteryLevel) === tier).length,
+  }));
+
+  const total = standards.length;
+
+  // SVG donut chart dimensions
+  const size = 160;
+  const strokeWidth = 28;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const cx = size / 2;
+  const cy = size / 2;
+
+  // Build arc segments
+  let cumulativePercent = 0;
+  const segments = tierCounts
+    .filter((t) => t.count > 0)
+    .map((tier) => {
+      const percent = tier.count / total;
+      const dashArray = `${circumference * percent} ${circumference * (1 - percent)}`;
+      const dashOffset = -circumference * cumulativePercent;
+      cumulativePercent += percent;
+      return { ...tier, percent, dashArray, dashOffset };
+    });
+
+  // Average mastery for center label
+  const avgMastery = Math.round(
+    standards.reduce((sum, s) => sum + s.masteryLevel, 0) / total
+  );
+
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white p-6">
+      <h2 className="text-lg font-semibold text-neutral-900">Mastery Overview</h2>
+      <p className="mt-1 text-xs text-neutral-500">
+        Distribution of your standards across mastery tiers
+      </p>
+
+      <div className="mt-5 flex items-center gap-6">
+        {/* Donut chart */}
+        <div className="relative shrink-0">
+          <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+            {/* Background ring */}
+            <circle
+              cx={cx}
+              cy={cy}
+              r={radius}
+              fill="none"
+              stroke="#f1f5f9"
+              strokeWidth={strokeWidth}
+            />
+            {/* Tier segments */}
+            {segments.map((seg) => (
+              <circle
+                key={seg.label}
+                cx={cx}
+                cy={cy}
+                r={radius}
+                fill="none"
+                stroke={seg.color}
+                strokeWidth={strokeWidth}
+                strokeDasharray={seg.dashArray}
+                strokeDashoffset={seg.dashOffset}
+                strokeLinecap="butt"
+                transform={`rotate(-90 ${cx} ${cy})`}
+                className="transition-all duration-700"
+              />
+            ))}
+          </svg>
+          {/* Center text */}
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span className="text-2xl font-bold text-neutral-900">{avgMastery}%</span>
+            <span className="text-[10px] text-neutral-500">avg mastery</span>
+          </div>
+        </div>
+
+        {/* Legend */}
+        <div className="flex flex-col gap-2.5">
+          {tierCounts.map((tier) => (
+            <div key={tier.label} className="flex items-center gap-2">
+              <span
+                className="inline-block h-3 w-3 rounded-sm"
+                style={{ backgroundColor: tier.color }}
+              />
+              <span className="text-sm text-neutral-700">
+                {tier.label}
+              </span>
+              <span className="text-sm font-semibold text-neutral-900">{tier.count}</span>
+              <span className="text-xs text-neutral-400">
+                ({total > 0 ? Math.round((tier.count / total) * 100) : 0}%)
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/progress/progress-summary.tsx
+++ b/src/components/progress/progress-summary.tsx
@@ -6,6 +6,7 @@ interface SummaryStats {
   masteredCount: number;
   inProgressCount: number;
   totalSessions: number;
+  streak: number;
 }
 
 function StatCard({ label, value, detail }: { label: string; value: string | number; detail?: string }) {
@@ -27,7 +28,7 @@ export function ProgressSummary({ summary }: { summary: SummaryStats }) {
     'Not started';
 
   return (
-    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
       <StatCard
         label="Average Mastery"
         value={`${summary.averageMastery}%`}
@@ -46,6 +47,11 @@ export function ProgressSummary({ summary }: { summary: SummaryStats }) {
       <StatCard
         label="Total Sessions"
         value={summary.totalSessions}
+      />
+      <StatCard
+        label="Current Streak"
+        value={`${summary.streak} day${summary.streak !== 1 ? 's' : ''}`}
+        detail={summary.streak > 0 ? 'consecutive days active' : 'start a session today!'}
       />
     </div>
   );

--- a/src/components/progress/session-timeline.tsx
+++ b/src/components/progress/session-timeline.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Session {
+  id: string;
+  subject: string;
+  currentPhase: string;
+  startedAt: string;
+  endedAt: string | null;
+  _count: { messages: number; assessments: number };
+}
+
+const SUBJECT_LABELS: Record<string, string> = {
+  MATH: 'Math',
+  SCIENCE: 'Science',
+  LANGUAGE_ARTS: 'ELA',
+};
+
+const SUBJECT_COLORS: Record<string, string> = {
+  MATH: '#3B82F6',
+  SCIENCE: '#10B981',
+  LANGUAGE_ARTS: '#8B5CF6',
+};
+
+const PHASE_LABELS: Record<string, string> = {
+  ROOT: 'Root',
+  REGULATE: 'Regulate',
+  REFLECT: 'Reflect',
+  RESTORE: 'Restore',
+  RECONNECT: 'Reconnect',
+};
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatTime(d: string) {
+  return new Date(d).toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatDuration(start: string, end: string | null) {
+  if (!end) return 'In progress';
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  const mins = Math.round(ms / 60000);
+  if (mins < 1) return '<1 min';
+  if (mins < 60) return `${mins} min`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ${mins % 60}m`;
+}
+
+function groupByDate(sessions: Session[]): Map<string, Session[]> {
+  const groups = new Map<string, Session[]>();
+  for (const s of sessions) {
+    const dateKey = new Date(s.startedAt).toISOString().slice(0, 10);
+    if (!groups.has(dateKey)) groups.set(dateKey, []);
+    groups.get(dateKey)!.push(s);
+  }
+  return groups;
+}
+
+export function SessionTimeline({ sessions }: { sessions: Session[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (sessions.length === 0) {
+    return (
+      <div className="rounded-xl border border-neutral-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-neutral-900">Session History</h2>
+        <p className="mt-3 text-sm text-neutral-500">
+          No sessions yet. Start your first tutoring session to see history here.
+        </p>
+      </div>
+    );
+  }
+
+  const grouped = groupByDate(sessions);
+  const dateEntries = Array.from(grouped.entries());
+  const visibleEntries = expanded ? dateEntries : dateEntries.slice(0, 5);
+
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white p-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-neutral-900">Session History</h2>
+          <p className="mt-1 text-xs text-neutral-500">
+            {sessions.length} recent session{sessions.length !== 1 ? 's' : ''}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-4">
+        {visibleEntries.map(([dateKey, daySessions]) => (
+          <div key={dateKey}>
+            {/* Date header */}
+            <div className="mb-2 flex items-center gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+                {formatDate(daySessions[0].startedAt)}
+              </span>
+              <span className="h-px flex-1 bg-neutral-100" />
+            </div>
+
+            {/* Session cards for this date */}
+            <div className="space-y-2">
+              {daySessions.map((s) => {
+                const color = SUBJECT_COLORS[s.subject] || '#6B7280';
+                return (
+                  <div
+                    key={s.id}
+                    className="flex items-stretch gap-3 rounded-lg border border-neutral-100 bg-neutral-50 p-3 transition-colors hover:bg-white"
+                  >
+                    {/* Subject color bar */}
+                    <div
+                      className="w-1 shrink-0 rounded-full"
+                      style={{ backgroundColor: color }}
+                    />
+
+                    {/* Content */}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-neutral-800">
+                          {SUBJECT_LABELS[s.subject] || s.subject}
+                        </span>
+                        <span className="rounded-full bg-neutral-200 px-1.5 py-0.5 text-[10px] font-medium text-neutral-600">
+                          {PHASE_LABELS[s.currentPhase] || s.currentPhase}
+                        </span>
+                        {!s.endedAt && (
+                          <span className="rounded-full bg-green-100 px-1.5 py-0.5 text-[10px] font-semibold text-green-700">
+                            Live
+                          </span>
+                        )}
+                      </div>
+
+                      <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-neutral-500">
+                        <span>{formatTime(s.startedAt)}</span>
+                        <span>{formatDuration(s.startedAt, s.endedAt)}</span>
+                        <span>{s._count.messages} msg{s._count.messages !== 1 ? 's' : ''}</span>
+                        {s._count.assessments > 0 && (
+                          <span>{s._count.assessments} assessment{s._count.assessments !== 1 ? 's' : ''}</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {dateEntries.length > 5 && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="mt-4 w-full rounded-lg border border-neutral-200 py-2 text-center text-xs font-medium text-neutral-600 transition-colors hover:bg-neutral-50"
+        >
+          {expanded ? 'Show less' : `Show all ${dateEntries.length} days`}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
…ends, session timeline

- Add MasteryOverview component with SVG donut chart showing mastery tier distribution (Mastered/Proficient/Developing/Beginning) with legend
- Add GrowthChart component with SVG line/area chart showing weekly assessment score trends with time range filters (7d/30d/90d/all)
- Add SessionTimeline component replacing the plain table with grouped date-based cards showing subject color bars, phase badges, and duration
- Enhance ProgressSummary with streak tracking (consecutive active days) and 5-column grid layout
- Update server data fetching with time-series assessment query and streak calculation for growth chart data

https://claude.ai/code/session_01Weu3umprVbG7mf2NUipQj4