### PR TITLE
Fix branding consistency across entire UI to match RootWork Framework…

### DIFF
--- a/src/app/admin/ingest/page.tsx
+++ b/src/app/admin/ingest/page.tsx
@@ -92,21 +92,21 @@ export default function IngestPage() {
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'SUCCESS': return 'bg-green-100 text-green-800';
-      case 'FAILURE': return 'bg-red-100 text-red-800';
-      case 'PROCESSING': return 'bg-blue-100 text-blue-800';
-      case 'PENDING': return 'bg-yellow-100 text-yellow-800';
-      default: return 'bg-gray-100 text-gray-800';
+      case 'SUCCESS': return 'bg-primary-100 text-primary-800';
+      case 'FAILURE': return 'bg-error-100 text-error-800';
+      case 'PROCESSING': return 'bg-info-100 text-info-800';
+      case 'PENDING': return 'bg-secondary-100 text-secondary-800';
+      default: return 'bg-neutral-100 text-neutral-800';
     }
   };
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">
+        <h1 className="text-3xl font-bold text-neutral-900 mb-2">
           Curriculum Ingestion Management
         </h1>
-        <p className="text-gray-600">
+        <p className="text-neutral-600">
           Monitor and manage curriculum data ingestion from n8n workflows
         </p>
       </div>
@@ -114,20 +114,20 @@ export default function IngestPage() {
       {/* Statistics Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
         <div className="bg-white rounded-lg shadow p-6">
-          <div className="text-sm font-medium text-gray-600 mb-1">Total Ingestions</div>
-          <div className="text-3xl font-bold text-gray-900">{stats.total}</div>
+          <div className="text-sm font-medium text-neutral-600 mb-1">Total Ingestions</div>
+          <div className="text-3xl font-bold text-neutral-900">{stats.total}</div>
         </div>
         <div className="bg-white rounded-lg shadow p-6">
-          <div className="text-sm font-medium text-gray-600 mb-1">Successful</div>
-          <div className="text-3xl font-bold text-green-600">{stats.success}</div>
+          <div className="text-sm font-medium text-neutral-600 mb-1">Successful</div>
+          <div className="text-3xl font-bold text-primary-600">{stats.success}</div>
         </div>
         <div className="bg-white rounded-lg shadow p-6">
-          <div className="text-sm font-medium text-gray-600 mb-1">Failed</div>
-          <div className="text-3xl font-bold text-red-600">{stats.failure}</div>
+          <div className="text-sm font-medium text-neutral-600 mb-1">Failed</div>
+          <div className="text-3xl font-bold text-error-600">{stats.failure}</div>
         </div>
         <div className="bg-white rounded-lg shadow p-6">
-          <div className="text-sm font-medium text-gray-600 mb-1">Processing</div>
-          <div className="text-3xl font-bold text-blue-600">{stats.processing}</div>
+          <div className="text-sm font-medium text-neutral-600 mb-1">Processing</div>
+          <div className="text-3xl font-bold text-info-600">{stats.processing}</div>
         </div>
       </div>
 
@@ -140,12 +140,12 @@ export default function IngestPage() {
               placeholder="Search logs..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="flex-1 px-4 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             />
             <select
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
-              className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="px-4 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
               <option value="ALL">All Status</option>
               <option value="SUCCESS">Success</option>
@@ -157,7 +157,7 @@ export default function IngestPage() {
           <button
             onClick={triggerIngestion}
             disabled={triggering}
-            className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+            className="px-6 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:bg-neutral-400 disabled:cursor-not-allowed transition-colors"
           >
             {triggering ? 'Triggering...' : 'Trigger Manual Ingestion'}
           </button>
@@ -167,42 +167,42 @@ export default function IngestPage() {
       {/* Logs Table */}
       <div className="bg-white rounded-lg shadow overflow-hidden">
         {loading ? (
-          <div className="p-8 text-center text-gray-500">
+          <div className="p-8 text-center text-neutral-500">
             Loading ingestion logs...
           </div>
         ) : filteredLogs.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">
+          <div className="p-8 text-center text-neutral-500">
             No logs found matching your criteria
           </div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-gray-50 border-b border-gray-200">
+              <thead className="bg-neutral-50 border-b border-neutral-200">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                     Timestamp
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                     Status
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                     Source
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                     Files
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                     Duration
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                     Details
                   </th>
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+              <tbody className="bg-white divide-y divide-neutral-200">
                 {filteredLogs.map((log) => (
-                  <tr key={log.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                  <tr key={log.id} className="hover:bg-neutral-50">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-900">
                       {format(new Date(log.timestamp), 'MMM d, yyyy HH:mm:ss')}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
@@ -210,22 +210,22 @@ export default function IngestPage() {
                         {log.status}
                       </span>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-900">
                       {log.source}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-900">
                       {log.processedFiles}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-500">
                       {log.durationMs ? `${log.durationMs}ms` : '-'}
                     </td>
-                    <td className="px-6 py-4 text-sm text-gray-500">
+                    <td className="px-6 py-4 text-sm text-neutral-500">
                       {log.errorMessage ? (
-                        <span className="text-red-600 truncate block max-w-xs" title={log.errorMessage}>
+                        <span className="text-error-600 truncate block max-w-xs" title={log.errorMessage}>
                           {log.errorMessage}
                         </span>
                       ) : (
-                        <span className="text-green-600">Success</span>
+                        <span className="text-primary-600">Success</span>
                       )}
                     </td>
                   </tr>

--- a/src/app/curriculum/topic/[topicId]/page.tsx
+++ b/src/app/curriculum/topic/[topicId]/page.tsx
@@ -275,7 +275,7 @@ export default async function TopicDetailPage({ params }: PageProps) {
                 <ul className="space-y-2">
                   {topic.commonMisconceptions.map((misconception, i) => (
                     <li key={i} className="flex gap-2 text-sm text-neutral-700">
-                      <span className="text-amber-600">•</span>
+                      <span className="text-secondary-600">•</span>
                       <span>{misconception}</span>
                     </li>
                   ))}
@@ -294,7 +294,7 @@ export default async function TopicDetailPage({ params }: PageProps) {
                 <ul className="space-y-2">
                   {topic.realWorldConnections.map((connection, i) => (
                     <li key={i} className="flex gap-2 text-sm text-neutral-700">
-                      <span className="text-green-600">•</span>
+                      <span className="text-primary-600">•</span>
                       <span>{connection}</span>
                     </li>
                   ))}

--- a/src/app/educator/classes/page.tsx
+++ b/src/app/educator/classes/page.tsx
@@ -61,12 +61,12 @@ export default function EducatorClassesPage() {
                   <button
                     key={item.id}
                     onClick={() => setSelectedClassId(item.id)}
-                    className={`rounded-lg border p-4 text-left ${selectedClassId === item.id ? 'border-blue-500 bg-blue-50' : 'border-neutral-200'}`}
+                    className={`rounded-lg border p-4 text-left ${selectedClassId === item.id ? 'border-primary-500 bg-primary-50' : 'border-neutral-200'}`}
                   >
                     <p className="font-semibold text-neutral-900">{item.name}</p>
                     <p className="mt-1 text-sm text-neutral-600">{item.subject} · {item.period}</p>
                     <p className="mt-2 text-sm text-neutral-700">Enrollment: {count}/{item.capacity}</p>
-                    {full && <p className="mt-1 text-xs font-medium text-amber-700">At capacity</p>}
+                    {full && <p className="mt-1 text-xs font-medium text-secondary-700">At capacity</p>}
                   </button>
                 );
               })}

--- a/src/app/educator/compliance/page.tsx
+++ b/src/app/educator/compliance/page.tsx
@@ -33,16 +33,16 @@ export default function EducatorCompliancePage() {
 
       <section className="rounded-xl border border-neutral-200 bg-white p-5 shadow-sm">
         <div className="mb-5 grid gap-3 sm:grid-cols-3">
-          <div className="rounded-lg bg-red-50 p-4">
-            <p className="text-xs uppercase text-red-700">Overdue items</p>
-            <p className="mt-1 text-2xl font-bold text-red-900">{overdue}</p>
+          <div className="rounded-lg bg-error-50 p-4">
+            <p className="text-xs uppercase text-error-700">Overdue items</p>
+            <p className="mt-1 text-2xl font-bold text-error-900">{overdue}</p>
           </div>
-          <div className="rounded-lg bg-violet-50 p-4">
-            <p className="text-xs uppercase text-violet-700">Students with IEPs</p>
-            <p className="mt-1 text-2xl font-bold text-violet-900">{iepStudents}</p>
+          <div className="rounded-lg bg-primary-50 p-4">
+            <p className="text-xs uppercase text-primary-700">Students with IEPs</p>
+            <p className="mt-1 text-2xl font-bold text-primary-900">{iepStudents}</p>
           </div>
-          <div className="rounded-lg bg-blue-50 p-4">
-            <p className="text-sm text-blue-800">Use filters and status updates to prep for audits and service reviews.</p>
+          <div className="rounded-lg bg-secondary-50 p-4">
+            <p className="text-sm text-secondary-800">Use filters and status updates to prep for audits and service reviews.</p>
           </div>
         </div>
 

--- a/src/app/educator/reports/page.tsx
+++ b/src/app/educator/reports/page.tsx
@@ -74,17 +74,17 @@ export default function EducatorReportsPage() {
         </div>
 
         <div className="mt-5 grid gap-3 sm:grid-cols-3">
-          <div className="rounded-lg bg-green-50 p-4">
-            <p className="text-xs uppercase text-green-700">Visible reports</p>
-            <p className="mt-1 text-2xl font-bold text-green-900">{filteredReports.length}</p>
+          <div className="rounded-lg bg-primary-50 p-4">
+            <p className="text-xs uppercase text-primary-700">Visible reports</p>
+            <p className="mt-1 text-2xl font-bold text-primary-900">{filteredReports.length}</p>
           </div>
-          <div className="rounded-lg bg-blue-50 p-4">
-            <p className="text-xs uppercase text-blue-700">Average mastery</p>
-            <p className="mt-1 text-2xl font-bold text-blue-900">{avgMastery}%</p>
+          <div className="rounded-lg bg-neutral-100 p-4">
+            <p className="text-xs uppercase text-neutral-700">Average mastery</p>
+            <p className="mt-1 text-2xl font-bold text-neutral-900">{avgMastery}%</p>
           </div>
-          <div className="rounded-lg bg-amber-50 p-4">
-            <p className="text-xs uppercase text-amber-700">At-risk learners</p>
-            <p className="mt-1 text-2xl font-bold text-amber-900">
+          <div className="rounded-lg bg-secondary-50 p-4">
+            <p className="text-xs uppercase text-secondary-700">At-risk learners</p>
+            <p className="mt-1 text-2xl font-bold text-secondary-900">
               {filteredReports.filter((item) => item.mastery < 70 || item.missingAssignments > 1).length}
             </p>
           </div>

--- a/src/app/educator/students/page.tsx
+++ b/src/app/educator/students/page.tsx
@@ -50,9 +50,9 @@ export default function EducatorStudentsPage() {
         <h1 className="text-3xl font-bold text-neutral-900">Student roster management</h1>
         <p className="mt-2 text-neutral-700">Track enrollment, support tiers, attendance, and IEP accommodations from one workspace.</p>
         <div className="mt-4 flex flex-wrap gap-3 text-sm">
-          <span className="rounded-full bg-blue-50 px-4 py-2 text-blue-700">Total students: {students.length}</span>
-          <span className="rounded-full bg-violet-50 px-4 py-2 text-violet-700">Students with IEPs: {iepCount}</span>
-          <span className="rounded-full bg-emerald-50 px-4 py-2 text-emerald-700">
+          <span className="rounded-full bg-primary-50 px-4 py-2 text-primary-700">Total students: {students.length}</span>
+          <span className="rounded-full bg-secondary-50 px-4 py-2 text-secondary-700">Students with IEPs: {iepCount}</span>
+          <span className="rounded-full bg-primary-50 px-4 py-2 text-primary-700">
             Avg attendance: {Math.round(students.reduce((sum, s) => sum + s.attendance, 0) / (students.length || 1))}%
           </span>
         </div>
@@ -95,7 +95,7 @@ export default function EducatorStudentsPage() {
                 {visibleStudents.map((student) => (
                   <tr
                     key={student.id}
-                    className={`cursor-pointer border-t border-neutral-100 ${selectedId === student.id ? 'bg-blue-50/60' : ''}`}
+                    className={`cursor-pointer border-t border-neutral-100 ${selectedId === student.id ? 'bg-primary-50/60' : ''}`}
                     onClick={() => setSelectedId(student.id)}
                   >
                     <td className="py-3 font-medium text-neutral-800">{student.name}</td>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,4 +64,11 @@
   --color-text-secondary: #a1a1aa;
   --color-text-muted: #71717a;
   --color-border: #27272a;
+  --color-background: var(--color-surface);
+  --color-foreground: var(--color-text-primary);
+  --color-muted: #27272a;
+  --color-muted-foreground: #a1a1aa;
+  --color-accent: #1e3a2f;
+  --color-accent-foreground: #dcfce7;
+  --color-input: #27272a;
 }

--- a/src/app/students/[studentId]/assessments/page.tsx
+++ b/src/app/students/[studentId]/assessments/page.tsx
@@ -39,7 +39,7 @@ export default async function StudentAssessmentsPage({ params }: PageProps) {
                 <CardDescription>Placement & gap analysis</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="text-3xl font-bold text-blue-600 mb-2">3</div>
+                <div className="text-3xl font-bold text-info-600 mb-2">3</div>
                 <p className="text-sm text-muted-foreground mb-4">Completed</p>
                 <Link href={`/assessments/diagnostic?studentId=${studentId}`}>
                   <Button variant="outline" size="sm" className="w-full">
@@ -55,7 +55,7 @@ export default async function StudentAssessmentsPage({ params }: PageProps) {
                 <CardDescription>In-session checks</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="text-3xl font-bold text-green-600 mb-2">12</div>
+                <div className="text-3xl font-bold text-primary-600 mb-2">12</div>
                 <p className="text-sm text-muted-foreground mb-4">Completed</p>
                 <Link href={`/assessments/formative?studentId=${studentId}&sessionId=session-123&topic=Current Topic`}><Button variant="outline" size="sm" className="w-full">Start Check</Button></Link>
               </CardContent>
@@ -67,7 +67,7 @@ export default async function StudentAssessmentsPage({ params }: PageProps) {
                 <CardDescription>Mastery evaluations</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="text-3xl font-bold text-purple-600 mb-2">5</div>
+                <div className="text-3xl font-bold text-subject-ela mb-2">5</div>
                 <p className="text-sm text-muted-foreground mb-4">Completed</p>
                 <Link href={`/assessments/summative?studentId=${studentId}&sessionId=session-123&topic=Current Topic`}><Button variant="outline" size="sm" className="w-full">Start New</Button></Link>
               </CardContent>

--- a/src/brand/tokens.css
+++ b/src/brand/tokens.css
@@ -71,6 +71,63 @@
   --color-info: #3b82f6;
 
   /* ─────────────────────────────────────────────────────────────────────
+     STATUS COLOR SHADES
+     ───────────────────────────────────────────────────────────────────── */
+
+  /* Error shades */
+  --color-error-50: #fef2f2;
+  --color-error-100: #fee2e2;
+  --color-error-200: #fecaca;
+  --color-error-500: #ef4444;
+  --color-error-600: #dc2626;
+  --color-error-700: #b91c1c;
+  --color-error-800: #991b1b;
+  --color-error-900: #7f1d1d;
+
+  /* Info shades */
+  --color-info-50: #eff6ff;
+  --color-info-100: #dbeafe;
+  --color-info-200: #bfdbfe;
+  --color-info-500: #3b82f6;
+  --color-info-600: #2563eb;
+  --color-info-700: #1d4ed8;
+  --color-info-800: #1e40af;
+  --color-info-900: #1e3a8a;
+
+  /* ─────────────────────────────────────────────────────────────────────
+     SUBJECT COLORS
+     ───────────────────────────────────────────────────────────────────── */
+
+  --color-subject-math: #3B82F6;
+  --color-subject-math-light: #eff6ff;
+  --color-subject-math-dark: #1e40af;
+
+  --color-subject-science: #10B981;
+  --color-subject-science-light: #ecfdf5;
+  --color-subject-science-dark: #065f46;
+
+  --color-subject-ela: #8B5CF6;
+  --color-subject-ela-light: #f5f3ff;
+  --color-subject-ela-dark: #5b21b6;
+
+  /* ─────────────────────────────────────────────────────────────────────
+     SHADCN/UI COMPATIBILITY
+     ───────────────────────────────────────────────────────────────────── */
+
+  --color-background: var(--color-surface);
+  --color-foreground: var(--color-text-primary);
+  --color-primary-foreground: #ffffff;
+  --color-secondary-foreground: var(--color-neutral-900);
+  --color-destructive: var(--color-error);
+  --color-destructive-foreground: #ffffff;
+  --color-muted: var(--color-neutral-100);
+  --color-muted-foreground: var(--color-neutral-500);
+  --color-accent: var(--color-primary-100);
+  --color-accent-foreground: var(--color-primary-900);
+  --color-input: var(--color-border);
+  --color-ring: var(--color-focus);
+
+  /* ─────────────────────────────────────────────────────────────────────
      TYPOGRAPHY
      ───────────────────────────────────────────────────────────────────── */
 

--- a/src/components/assessments/AssessmentCard.tsx
+++ b/src/components/assessments/AssessmentCard.tsx
@@ -34,12 +34,12 @@ interface AssessmentCardProps {
 type AssessmentType = 'DIAGNOSTIC' | 'FORMATIVE' | 'SUMMATIVE' | 'PRACTICE';
 
 const BLOOMS_COLORS: Record<BloomsLevel, string> = {
-  REMEMBER: 'bg-blue-100 text-blue-800',
-  UNDERSTAND: 'bg-green-100 text-green-800',
-  APPLY: 'bg-yellow-100 text-yellow-800',
-  ANALYZE: 'bg-orange-100 text-orange-800',
-  EVALUATE: 'bg-red-100 text-red-800',
-  CREATE: 'bg-purple-100 text-purple-800',
+  REMEMBER: 'bg-neutral-100 text-neutral-800',
+  UNDERSTAND: 'bg-info-100 text-info-800',
+  APPLY: 'bg-primary-100 text-primary-800',
+  ANALYZE: 'bg-secondary-100 text-secondary-800',
+  EVALUATE: 'bg-error-100 text-error-800',
+  CREATE: 'bg-subject-ela-light text-subject-ela-dark',
 };
 
 const DIFFICULTY_STARS = ['⭐', '⭐⭐', '⭐⭐⭐', '⭐⭐⭐⭐', '⭐⭐⭐⭐⭐'];
@@ -121,10 +121,10 @@ export function AssessmentCard({
             )}
 
             {showHints && hintLevel > 0 && (
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 space-y-2">
-                <p className="font-semibold text-blue-900">Hints:</p>
+              <div className="bg-info-50 border border-info-200 rounded-lg p-4 space-y-2">
+                <p className="font-semibold text-info-900">Hints:</p>
                 {scaffoldHints.slice(0, hintLevel).map((hint, index) => (
-                  <p key={index} className="text-sm text-blue-800">
+                  <p key={index} className="text-sm text-info-800">
                     {index + 1}. {hint}
                   </p>
                 ))}
@@ -135,7 +135,7 @@ export function AssessmentCard({
 
         {showFeedback && feedback && (
           <div className={`rounded-lg p-4 ${
-            feedback.isCorrect ? 'bg-green-50 border border-green-200' : 'bg-yellow-50 border border-yellow-200'
+            feedback.isCorrect ? 'bg-primary-50 border border-primary-200' : 'bg-secondary-50 border border-secondary-200'
           }`}>
             <div className="flex items-center gap-2 mb-2">
               <span className="text-2xl">{feedback.isCorrect ? '✓' : '?'}</span>
@@ -152,7 +152,7 @@ export function AssessmentCard({
               <div className="mt-4 space-y-2">
                 <p className="font-semibold text-sm">Try thinking about:</p>
                 {feedback.scaffoldHints.map((hint, index) => (
-                  <p key={index} className="text-sm text-gray-700">
+                  <p key={index} className="text-sm text-neutral-700">
                     • {hint}
                   </p>
                 ))}

--- a/src/components/assessments/AssessmentHistory.tsx
+++ b/src/components/assessments/AssessmentHistory.tsx
@@ -31,10 +31,10 @@ interface HistoricalAssessment {
 }
 
 const TYPE_COLORS: Record<AssessmentType, string> = {
-  DIAGNOSTIC: 'bg-blue-100 text-blue-800',
-  FORMATIVE: 'bg-green-100 text-green-800',
-  SUMMATIVE: 'bg-purple-100 text-purple-800',
-  PRACTICE: 'bg-yellow-100 text-yellow-800',
+  DIAGNOSTIC: 'bg-info-100 text-info-800',
+  FORMATIVE: 'bg-primary-100 text-primary-800',
+  SUMMATIVE: 'bg-subject-ela-light text-subject-ela-dark',
+  PRACTICE: 'bg-secondary-100 text-secondary-800',
 };
 
 export function AssessmentHistory({
@@ -134,7 +134,7 @@ export function AssessmentHistory({
 
           {/* Summary Stats */}
           {filteredAssessments.length > 0 && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6 p-4 bg-gray-50 rounded-lg">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6 p-4 bg-neutral-50 rounded-lg">
               <div className="text-center">
                 <div className="text-2xl font-bold text-primary">
                   {filteredAssessments.length}
@@ -148,13 +148,13 @@ export function AssessmentHistory({
                 <div className="text-xs text-muted-foreground">Avg Score</div>
               </div>
               <div className="text-center">
-                <div className="text-2xl font-bold text-green-600">
+                <div className="text-2xl font-bold text-primary-600">
                   {filteredAssessments.filter((a) => a.isCorrect).length}
                 </div>
                 <div className="text-xs text-muted-foreground">Correct</div>
               </div>
               <div className="text-center">
-                <div className="text-2xl font-bold text-red-600">
+                <div className="text-2xl font-bold text-error-600">
                   {filteredAssessments.filter((a) => a.isCorrect === false).length}
                 </div>
                 <div className="text-xs text-muted-foreground">Incorrect</div>
@@ -172,7 +172,7 @@ export function AssessmentHistory({
               filteredAssessments.map((assessment) => (
                 <div
                   key={assessment.id}
-                  className="border rounded-lg p-4 hover:bg-gray-50 transition-colors"
+                  className="border rounded-lg p-4 hover:bg-neutral-50 transition-colors"
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex-1">

--- a/src/components/assessments/AssessmentResults.tsx
+++ b/src/components/assessments/AssessmentResults.tsx
@@ -24,12 +24,12 @@ interface AssessmentResultsProps {
 }
 
 const BLOOMS_COLORS: Record<BloomsLevel, string> = {
-  REMEMBER: 'bg-blue-100 text-blue-800',
-  UNDERSTAND: 'bg-green-100 text-green-800',
-  APPLY: 'bg-yellow-100 text-yellow-800',
-  ANALYZE: 'bg-orange-100 text-orange-800',
-  EVALUATE: 'bg-red-100 text-red-800',
-  CREATE: 'bg-purple-100 text-purple-800',
+  REMEMBER: 'bg-neutral-100 text-neutral-800',
+  UNDERSTAND: 'bg-info-100 text-info-800',
+  APPLY: 'bg-primary-100 text-primary-800',
+  ANALYZE: 'bg-secondary-100 text-secondary-800',
+  EVALUATE: 'bg-error-100 text-error-800',
+  CREATE: 'bg-subject-ela-light text-subject-ela-dark',
 };
 
 export function AssessmentResults({
@@ -84,17 +84,17 @@ export function AssessmentResults({
 
           <div className="grid grid-cols-3 gap-4 pt-4 border-t">
             <div className="text-center">
-              <div className="text-2xl font-bold text-green-600">{correctCount}</div>
+              <div className="text-2xl font-bold text-primary-600">{correctCount}</div>
               <div className="text-xs text-muted-foreground">Correct</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-red-600">
+              <div className="text-2xl font-bold text-error-600">
                 {totalCount - correctCount}
               </div>
               <div className="text-xs text-muted-foreground">Incorrect</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-blue-600">{totalCount}</div>
+              <div className="text-2xl font-bold text-info-600">{totalCount}</div>
               <div className="text-xs text-muted-foreground">Total</div>
             </div>
           </div>
@@ -146,8 +146,8 @@ export function AssessmentResults({
               key={assessment.id}
               className={`border rounded-lg p-4 ${
                 assessment.isCorrect
-                  ? 'border-green-200 bg-green-50'
-                  : 'border-yellow-200 bg-yellow-50'
+                  ? 'border-primary-200 bg-primary-50'
+                  : 'border-secondary-200 bg-secondary-50'
               }`}
             >
               <div className="flex items-start justify-between mb-2">

--- a/src/components/assessments/FormativeCheck.tsx
+++ b/src/components/assessments/FormativeCheck.tsx
@@ -184,7 +184,7 @@ export function FormativeCheck({
 
         {feedback && (
           <div className={`rounded-lg p-4 ${
-            feedback.isCorrect ? 'bg-green-50 border border-green-200' : 'bg-blue-50 border border-blue-200'
+            feedback.isCorrect ? 'bg-primary-50 border border-primary-200' : 'bg-info-50 border border-info-200'
           }`}>
             <div className="flex items-center gap-2 mb-2">
               <span className="text-xl">{feedback.isCorrect ? '✓' : '?'}</span>

--- a/src/components/assessments/ReasoningMoveTracker.tsx
+++ b/src/components/assessments/ReasoningMoveTracker.tsx
@@ -38,11 +38,11 @@ interface Profile {
 }
 
 const PROFICIENCY_COLORS: Record<number, string> = {
-  1: 'bg-gray-200 text-gray-700',
-  2: 'bg-blue-200 text-blue-700',
-  3: 'bg-yellow-200 text-yellow-700',
-  4: 'bg-green-200 text-green-700',
-  5: 'bg-purple-200 text-purple-700',
+  1: 'bg-neutral-200 text-neutral-700',
+  2: 'bg-info-200 text-info-700',
+  3: 'bg-secondary-200 text-secondary-700',
+  4: 'bg-primary-200 text-primary-700',
+  5: 'bg-subject-ela-light text-subject-ela-dark',
 };
 
 const PROFICIENCY_LABELS: Record<number, string> = {
@@ -195,7 +195,7 @@ export function ReasoningMoveTracker({ studentId, showSuggestions = true }: Reas
               {suggestions.map((suggestion, index) => (
                 <div
                   key={index}
-                  className="flex items-center gap-3 p-3 bg-blue-50 rounded-lg border border-blue-200"
+                  className="flex items-center gap-3 p-3 bg-info-50 rounded-lg border border-info-200"
                 >
                   <span className="text-2xl">→</span>
                   <div className="flex-1">

--- a/src/components/assessments/SummativeAssessment.tsx
+++ b/src/components/assessments/SummativeAssessment.tsx
@@ -202,7 +202,7 @@ export function SummativeAssessment({
               </CardDescription>
             </div>
             {timeRemaining !== null && (
-              <div className={`text-2xl font-bold ${timeRemaining < 300 ? 'text-red-600' : 'text-primary'}`}>
+              <div className={`text-2xl font-bold ${timeRemaining < 300 ? 'text-error-600' : 'text-primary'}`}>
                 ⏱️ {formatTime(timeRemaining)}
               </div>
             )}
@@ -282,7 +282,7 @@ export function SummativeAssessment({
             </div>
 
             <div className="space-y-4">
-              <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-neutral-50 rounded-lg">
                 <div>
                   <div className="font-semibold">
                     {Object.keys(responses).length} / {assessments.length} questions answered

--- a/src/components/assessments/ThinkingAssessment.tsx
+++ b/src/components/assessments/ThinkingAssessment.tsx
@@ -132,7 +132,7 @@ export function ThinkingAssessment({
                     className={`p-4 rounded-lg border-2 text-left transition-all ${
                       selectedMode === m
                         ? 'border-primary bg-primary/5'
-                        : 'border-gray-200 hover:border-gray-300'
+                        : 'border-neutral-200 hover:border-neutral-300'
                     }`}
                   >
                     <div className="flex items-center gap-2 mb-2">
@@ -147,13 +147,13 @@ export function ThinkingAssessment({
               </div>
             </div>
 
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <div className="bg-info-50 border border-info-200 rounded-lg p-4">
               <h4 className="font-semibold mb-2">Problem Context:</h4>
               <p className="text-sm whitespace-pre-wrap">{problemContext}</p>
             </div>
 
             {targetReasoningMoves.length > 0 && (
-              <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
+              <div className="bg-subject-ela-light border border-subject-ela/20 rounded-lg p-4">
                 <h4 className="font-semibold mb-2">Focus on these thinking moves:</h4>
                 <div className="flex flex-wrap gap-2">
                   {targetReasoningMoves.map((move) => (
@@ -223,7 +223,7 @@ export function ThinkingAssessment({
                     <div className="text-sm text-muted-foreground mb-1">
                       {key.replace(/([A-Z])/g, ' $1').trim()}
                     </div>
-                    <div className="text-2xl font-bold text-purple-600">{value}/5</div>
+                    <div className="text-2xl font-bold text-subject-ela">{value}/5</div>
                   </div>
                 ))}
               </div>
@@ -244,19 +244,19 @@ export function ThinkingAssessment({
             )}
 
             {/* AI Analysis */}
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <div className="bg-info-50 border border-info-200 rounded-lg p-4">
               <h4 className="font-semibold mb-2">Detailed Analysis</h4>
               <p className="text-sm whitespace-pre-wrap">{evaluation.aiAnalysis}</p>
             </div>
 
             {/* Strengths */}
             {evaluation.strengths.length > 0 && (
-              <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+              <div className="bg-primary-50 border border-primary-200 rounded-lg p-4">
                 <h4 className="font-semibold mb-2">✨ Strengths</h4>
                 <ul className="space-y-1">
                   {evaluation.strengths.map((strength: string, index: number) => (
                     <li key={index} className="text-sm flex items-start gap-2">
-                      <span className="text-green-600">•</span>
+                      <span className="text-primary-600">•</span>
                       <span>{strength}</span>
                     </li>
                   ))}
@@ -266,12 +266,12 @@ export function ThinkingAssessment({
 
             {/* Areas for Growth */}
             {evaluation.areasForGrowth.length > 0 && (
-              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+              <div className="bg-secondary-50 border border-secondary-200 rounded-lg p-4">
                 <h4 className="font-semibold mb-2">Areas for Growth</h4>
                 <ul className="space-y-1">
                   {evaluation.areasForGrowth.map((area: string, index: number) => (
                     <li key={index} className="text-sm flex items-start gap-2">
-                      <span className="text-yellow-600">•</span>
+                      <span className="text-secondary-600">•</span>
                       <span>{area}</span>
                     </li>
                   ))}
@@ -302,12 +302,12 @@ export function ThinkingAssessment({
       </CardHeader>
 
       <CardContent className="space-y-6">
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+        <div className="bg-info-50 border border-info-200 rounded-lg p-4">
           <h4 className="font-semibold mb-2">Your Task:</h4>
           <p className="text-sm whitespace-pre-wrap">{prompt}</p>
         </div>
 
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+        <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4">
           <h4 className="font-semibold mb-2">Problem:</h4>
           <p className="text-sm whitespace-pre-wrap">{problemContext}</p>
         </div>

--- a/src/components/curriculum/mastery-indicator.tsx
+++ b/src/components/curriculum/mastery-indicator.tsx
@@ -15,10 +15,10 @@ export function MasteryIndicator({
 }: MasteryIndicatorProps) {
   const clamped = Math.min(100, Math.max(0, masteryLevel));
   
-  const color = 
-    clamped >= 80 ? 'bg-green-500' :
-    clamped >= 40 ? 'bg-yellow-500' :
-    'bg-red-500';
+  const color =
+    clamped >= 80 ? 'bg-primary-500' :
+    clamped >= 40 ? 'bg-secondary-500' :
+    'bg-error-500';
   
   const label =
     clamped >= 80 ? 'Mastered' :

--- a/src/components/curriculum/standard-badge.tsx
+++ b/src/components/curriculum/standard-badge.tsx
@@ -3,9 +3,9 @@ import { StandardFramework, Subject } from '@prisma/client';
 import * as Tooltip from '@radix-ui/react-tooltip';
 
 const SUBJECT_COLORS = {
-  MATH: 'bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100',
-  SCIENCE: 'bg-green-50 text-green-700 border-green-200 hover:bg-green-100',
-  LANGUAGE_ARTS: 'bg-purple-50 text-purple-700 border-purple-200 hover:bg-purple-100',
+  MATH: 'bg-subject-math-light text-subject-math-dark border-subject-math/20 hover:bg-subject-math-light/80',
+  SCIENCE: 'bg-subject-science-light text-subject-science-dark border-subject-science/20 hover:bg-subject-science-light/80',
+  LANGUAGE_ARTS: 'bg-subject-ela-light text-subject-ela-dark border-subject-ela/20 hover:bg-subject-ela-light/80',
 } as const;
 
 interface StandardBadgeProps {

--- a/src/components/curriculum/subject-badge.tsx
+++ b/src/components/curriculum/subject-badge.tsx
@@ -2,9 +2,9 @@ import { Badge } from '@/components/ui/badge';
 import { Subject } from '@prisma/client';
 
 const SUBJECT_COLORS = {
-  MATH: 'bg-blue-100 text-blue-800 border-blue-200',
-  SCIENCE: 'bg-green-100 text-green-800 border-green-200',
-  LANGUAGE_ARTS: 'bg-purple-100 text-purple-800 border-purple-200',
+  MATH: 'bg-subject-math-light text-subject-math-dark border-subject-math/20',
+  SCIENCE: 'bg-subject-science-light text-subject-science-dark border-subject-science/20',
+  LANGUAGE_ARTS: 'bg-subject-ela-light text-subject-ela-dark border-subject-ela/20',
 } as const;
 
 const SUBJECT_LABELS = {

--- a/src/components/learn/SessionHeader.tsx
+++ b/src/components/learn/SessionHeader.tsx
@@ -64,10 +64,10 @@ export function SessionHeader({
               <div
                 className={`h-full rounded-full transition-all duration-500 ${
                   regulationLevel > 60
-                    ? 'bg-green-500'
+                    ? 'bg-primary-500'
                     : regulationLevel > 40
-                      ? 'bg-yellow-500'
-                      : 'bg-red-500'
+                      ? 'bg-secondary-500'
+                      : 'bg-error-500'
                 }`}
                 style={{ width: `${regulationLevel}%` }}
               />

--- a/src/components/progress/blooms-taxonomy.tsx
+++ b/src/components/progress/blooms-taxonomy.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 const BLOOMS_LEVELS = [
-  { key: 'REMEMBER',    label: 'Remember',    color: '#94a3b8', description: 'Recall facts' },
-  { key: 'UNDERSTAND',  label: 'Understand',  color: '#60a5fa', description: 'Explain ideas' },
-  { key: 'APPLY',       label: 'Apply',       color: '#34d399', description: 'Use in context' },
-  { key: 'ANALYZE',     label: 'Analyze',     color: '#fbbf24', description: 'Break apart' },
-  { key: 'EVALUATE',    label: 'Evaluate',    color: '#f97316', description: 'Judge & justify' },
-  { key: 'CREATE',      label: 'Create',      color: '#ef4444', description: 'Generate new' },
+  { key: 'REMEMBER',    label: 'Remember',    color: 'var(--color-neutral-400)', description: 'Recall facts' },
+  { key: 'UNDERSTAND',  label: 'Understand',  color: 'var(--color-info-500)',    description: 'Explain ideas' },
+  { key: 'APPLY',       label: 'Apply',       color: 'var(--color-primary-500)', description: 'Use in context' },
+  { key: 'ANALYZE',     label: 'Analyze',     color: 'var(--color-secondary-500)', description: 'Break apart' },
+  { key: 'EVALUATE',    label: 'Evaluate',    color: 'var(--color-secondary-600)', description: 'Judge & justify' },
+  { key: 'CREATE',      label: 'Create',      color: 'var(--color-subject-ela)', description: 'Generate new' },
 ] as const;
 
 interface Standard {
@@ -83,7 +83,7 @@ export function BloomsTaxonomy({ standards, assessments = [] }: BloomsTaxonomyPr
               className="relative flex items-center justify-center rounded-md py-2 text-center transition-all"
               style={{
                 width: `${widthPercent}%`,
-                backgroundColor: isActive ? level.color : '#f1f5f9',
+                backgroundColor: isActive ? level.color : 'var(--color-neutral-100)',
                 opacity: isActive ? 1 : 0.5,
               }}
             >

--- a/src/components/progress/mastery-by-standard.tsx
+++ b/src/components/progress/mastery-by-standard.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 const SUBJECT_COLORS: Record<string, string> = {
-  MATH: '#3B82F6',
-  SCIENCE: '#10B981',
-  LANGUAGE_ARTS: '#8B5CF6',
+  MATH: 'var(--color-subject-math)',
+  SCIENCE: 'var(--color-subject-science)',
+  LANGUAGE_ARTS: 'var(--color-subject-ela)',
 };
 
 const SUBJECT_LABELS: Record<string, string> = {
@@ -19,7 +19,7 @@ interface MasteryBarProps {
   assessmentCount?: number;
 }
 
-function MasteryBar({ label, value, color = '#3B82F6', assessmentCount }: MasteryBarProps) {
+function MasteryBar({ label, value, color = 'var(--color-subject-math)', assessmentCount }: MasteryBarProps) {
   const clamped = Math.min(100, Math.max(0, value));
   const tier =
     clamped >= 80 ? 'Mastered' :
@@ -83,7 +83,7 @@ export function MasteryByStandard({ standards }: { standards: Standard[] }) {
           <div className="mb-3 flex items-center gap-2">
             <span
               className="inline-block h-3 w-3 rounded-full"
-              style={{ backgroundColor: SUBJECT_COLORS[subject] || '#6B7280' }}
+              style={{ backgroundColor: SUBJECT_COLORS[subject] || 'var(--color-neutral-500)' }}
             />
             <span className="text-sm font-semibold text-neutral-700">
               {SUBJECT_LABELS[subject] || subject}

--- a/src/components/progress/reasoning-move-chart.tsx
+++ b/src/components/progress/reasoning-move-chart.tsx
@@ -26,12 +26,12 @@ const MOVE_LABELS: Record<string, string> = {
 };
 
 const PROFICIENCY_COLORS = [
-  'bg-neutral-200',  // level 0 (unused)
-  'bg-amber-400',    // level 1
-  'bg-yellow-400',   // level 2
-  'bg-lime-500',     // level 3
-  'bg-emerald-500',  // level 4
-  'bg-green-600',    // level 5
+  'bg-neutral-200',    // level 0 (unused)
+  'bg-secondary-400',  // level 1
+  'bg-secondary-300',  // level 2
+  'bg-primary-400',    // level 3
+  'bg-primary-500',    // level 4
+  'bg-primary-600',    // level 5
 ];
 
 const PROFICIENCY_LABELS = ['', 'Introduced', 'Developing', 'Practicing', 'Proficient', 'Expert'];
@@ -80,13 +80,13 @@ export function ReasoningMoveChart({ moves }: { moves: ReasoningMove[] }) {
               <div className="flex h-2.5 w-full gap-0.5 overflow-hidden rounded-full bg-neutral-100">
                 {/* Prompted usage */}
                 <div
-                  className="h-full rounded-l-full bg-amber-400 transition-all duration-500"
+                  className="h-full rounded-l-full bg-secondary-400 transition-all duration-500"
                   style={{ width: `${(m.promptedUsage / maxUsage) * 100}%` }}
                   title={`Prompted: ${m.promptedUsage}`}
                 />
                 {/* Spontaneous usage */}
                 <div
-                  className="h-full rounded-r-full bg-emerald-500 transition-all duration-500"
+                  className="h-full rounded-r-full bg-primary-500 transition-all duration-500"
                   style={{ width: `${(m.spontaneousUsage / maxUsage) * 100}%` }}
                   title={`Spontaneous: ${m.spontaneousUsage}`}
                 />
@@ -98,10 +98,10 @@ export function ReasoningMoveChart({ moves }: { moves: ReasoningMove[] }) {
 
       <div className="mt-4 flex items-center gap-4 text-[11px] text-neutral-500">
         <span className="flex items-center gap-1">
-          <span className="inline-block h-2 w-4 rounded-full bg-amber-400" /> Prompted
+          <span className="inline-block h-2 w-4 rounded-full bg-secondary-400" /> Prompted
         </span>
         <span className="flex items-center gap-1">
-          <span className="inline-block h-2 w-4 rounded-full bg-emerald-500" /> Spontaneous
+          <span className="inline-block h-2 w-4 rounded-full bg-primary-500" /> Spontaneous
         </span>
       </div>
     </div>

--- a/src/components/progress/session-history.tsx
+++ b/src/components/progress/session-history.tsx
@@ -16,9 +16,9 @@ const SUBJECT_LABELS: Record<string, string> = {
 };
 
 const SUBJECT_DOT_COLORS: Record<string, string> = {
-  MATH: 'bg-blue-500',
-  SCIENCE: 'bg-emerald-500',
-  LANGUAGE_ARTS: 'bg-violet-500',
+  MATH: 'bg-subject-math',
+  SCIENCE: 'bg-subject-science',
+  LANGUAGE_ARTS: 'bg-subject-ela',
 };
 
 const PHASE_LABELS: Record<string, string> = {

--- a/src/components/tutoring/chat-interface.tsx
+++ b/src/components/tutoring/chat-interface.tsx
@@ -237,7 +237,7 @@ export function ChatInterface({
 
       {/* Error display */}
       {error && (
-        <div className="border-t bg-red-50 px-4 py-3 text-sm text-red-700" role="alert" aria-live="assertive">
+        <div className="border-t bg-error-50 px-4 py-3 text-sm text-error-700" role="alert" aria-live="assertive">
           {error}
         </div>
       )}

--- a/src/components/tutoring/message-bubble.tsx
+++ b/src/components/tutoring/message-bubble.tsx
@@ -55,7 +55,7 @@ export function MessageBubble({ role, content, timestamp, className }: MessageBu
         <div
           className={cn(
             'rounded-lg px-4 py-3',
-            isAssistant && 'bg-blue-50 text-neutral-900',
+            isAssistant && 'bg-primary-50 text-neutral-900',
             isUser && 'bg-neutral-200 text-neutral-900'
           )}
         >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,8 @@ const config: Config = {
     extend: {
       colors: {
         primary: {
+          DEFAULT: "var(--color-primary-600)",
+          foreground: "var(--color-primary-foreground)",
           50: "var(--color-primary-50)",
           100: "var(--color-primary-100)",
           200: "var(--color-primary-200)",
@@ -24,6 +26,8 @@ const config: Config = {
           950: "var(--color-primary-950)",
         },
         secondary: {
+          DEFAULT: "var(--color-secondary-500)",
+          foreground: "var(--color-secondary-foreground)",
           50: "var(--color-secondary-50)",
           100: "var(--color-secondary-100)",
           200: "var(--color-secondary-200)",
@@ -34,6 +38,74 @@ const config: Config = {
           700: "var(--color-secondary-700)",
           800: "var(--color-secondary-800)",
           900: "var(--color-secondary-900)",
+        },
+        destructive: {
+          DEFAULT: "var(--color-destructive)",
+          foreground: "var(--color-destructive-foreground)",
+        },
+        muted: {
+          DEFAULT: "var(--color-muted)",
+          foreground: "var(--color-muted-foreground)",
+        },
+        accent: {
+          DEFAULT: "var(--color-accent)",
+          foreground: "var(--color-accent-foreground)",
+        },
+        background: "var(--color-background)",
+        foreground: "var(--color-foreground)",
+        ring: "var(--color-ring)",
+        input: "var(--color-input)",
+        border: "var(--color-border)",
+        error: {
+          DEFAULT: "var(--color-error-500)",
+          50: "var(--color-error-50)",
+          100: "var(--color-error-100)",
+          200: "var(--color-error-200)",
+          500: "var(--color-error-500)",
+          600: "var(--color-error-600)",
+          700: "var(--color-error-700)",
+          800: "var(--color-error-800)",
+          900: "var(--color-error-900)",
+        },
+        info: {
+          DEFAULT: "var(--color-info-500)",
+          50: "var(--color-info-50)",
+          100: "var(--color-info-100)",
+          200: "var(--color-info-200)",
+          500: "var(--color-info-500)",
+          600: "var(--color-info-600)",
+          700: "var(--color-info-700)",
+          800: "var(--color-info-800)",
+          900: "var(--color-info-900)",
+        },
+        subject: {
+          math: {
+            DEFAULT: "var(--color-subject-math)",
+            light: "var(--color-subject-math-light)",
+            dark: "var(--color-subject-math-dark)",
+          },
+          science: {
+            DEFAULT: "var(--color-subject-science)",
+            light: "var(--color-subject-science-light)",
+            dark: "var(--color-subject-science-dark)",
+          },
+          ela: {
+            DEFAULT: "var(--color-subject-ela)",
+            light: "var(--color-subject-ela-light)",
+            dark: "var(--color-subject-ela-dark)",
+          },
+        },
+        neutral: {
+          50: "var(--color-neutral-50)",
+          100: "var(--color-neutral-100)",
+          200: "var(--color-neutral-200)",
+          300: "var(--color-neutral-300)",
+          400: "var(--color-neutral-400)",
+          500: "var(--color-neutral-500)",
+          600: "var(--color-neutral-600)",
+          700: "var(--color-neutral-700)",
+          800: "var(--color-neutral-800)",
+          900: "var(--color-neutral-900)",
         },
         phase: {
           root: "var(--phase-root-color)",


### PR DESCRIPTION
… style guide

Foundation changes:
- Add missing shadcn/UI compatibility CSS variables (primary-foreground, secondary-foreground, destructive, muted, accent, background, foreground, ring, input) mapped to RootWork brand tokens
- Add status color shades (error-50..900, info-50..900) to design tokens
- Add subject color tokens (math, science, ELA) with light/dark variants
- Extend Tailwind config with DEFAULT values, semantic colors (error, info, subject, muted, accent, destructive), and neutral palette from brand tokens
- Add dark mode overrides for new shadcn compatibility variables

Component fixes (27 files):
- Replace all non-brand Tailwind colors (blue-*, green-*, red-*, gray-*, purple-*, violet-*, emerald-*, amber-*, yellow-*, lime-*, orange-*) with brand-aligned equivalents (primary-*, secondary-*, neutral-*, error-*, info-*, subject-*)
- Standardize Bloom's taxonomy colors to use brand palette progression
- Standardize proficiency level colors to brand primary/secondary scale
- Standardize subject badge/dot colors to semantic subject-math/science/ela
- Standardize feedback panels (correct=primary, incorrect=secondary, hints=info, errors=error)
- Replace all hardcoded hex colors in chart data with CSS variable references

https://claude.ai/code/session_01UqE9mWiagVaB85Kgt1gFup