### PR TITLE
Implement curriculum ingestion, OpenAI embeddings + Pinecone upsert, and metadata‑aware RAG retrieval with caching

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,12 +2,15 @@ import { auth } from '@clerk/nextjs/server';
 import { db } from '@/lib/db';
 import { anthropic, AI_MODELS } from '@/lib/ai/client';
 import { buildMasterSystemPrompt } from '@/lib/ai/prompts/master-system-prompt';
-import { generateEmbedding } from '@/lib/pinecone/embeddings';
-import { queryPinecone } from '@/lib/pinecone/client';
+import { searchCurriculum, formatCurriculumContext } from '@/lib/vector-search';
 import { enforceUsageLimits, UsageLimitError } from '@/lib/usage-limits';
 import { detectDysregulation, updateRegulationLevel } from '@/lib/regulation/detector';
 import { analyzeThinkingQuality } from '@/lib/trace/tracker';
 import { getRecommendedPhaseTransition } from '@/lib/five-rs/phase-transition';
+import { withApiHandler } from '@/lib/api-handler';
+import { AuthenticationError, ForbiddenError, NotFoundError, PaymentRequiredError, ValidationError } from '@/lib/api-errors';
+import { incrementMetric, observeLatency } from '@/lib/api/metrics';
+import { logger } from '@/lib/logger';
 import { z } from 'zod';
 
 const chatRequestSchema = z.object({
@@ -147,35 +150,18 @@ export const POST = withApiHandler(async (req, { requestId }) => {
   try {
     const ragStartTime = Date.now();
 
-    // Generate embedding for the user's query
-    const queryEmbedding = await generateEmbedding(body.message);
-
-    // Query Pinecone for relevant curriculum content
-    const filter: Record<string, any> = {
+    const matches = await searchCurriculum(body.message, {
       subject: session.subject,
-    };
-
-    // Add grade level filter if available
-    if (user.student.gradeLevel) {
-      filter.gradeLevel = user.student.gradeLevel;
-    }
-
-    const matches = await queryPinecone(queryEmbedding, 5, filter);
+      gradeLevel: user.student.gradeLevel ?? undefined,
+      topK: 6,
+      minScore: 0.35,
+    });
     ragMetrics.retrieved = matches.length;
     ragMetrics.durationMs = Date.now() - ragStartTime;
 
     // Format retrieved context
     if (matches.length > 0) {
-      curriculumContext = matches
-        .map((match: { metadata?: Record<string, unknown>; score?: number }, idx: number) => {
-          const metadata = (match.metadata as Record<string, string>) || {};
-          const content = metadata.content || metadata.text || 'No content available';
-          const source = metadata.source || metadata.title || 'Unknown source';
-          const score = match.score?.toFixed(3) || 'N/A';
-
-          return `[Context ${idx + 1}] (Relevance: ${score})\nSource: ${source}\n${content}`;
-        })
-        .join('\n\n---\n\n');
+      curriculumContext = formatCurriculumContext(matches);
 
       logger.info('RAG context retrieved', {
         requestId,

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { z } from 'zod';
-import { chunkText, generateEmbeddings } from '@/lib/embeddings';
-import { upsertVectors, type CurriculumMetadata } from '@/lib/pinecone';
+import { generateEmbeddings } from '@/lib/embeddings';
+import { upsertVectors } from '@/lib/pinecone';
 import { logger } from '@/lib/logger';
+import { withApiHandler } from '@/lib/api-handler';
+import { AuthenticationError, ValidationError } from '@/lib/api-errors';
+import { parseCurriculumFile } from '@/lib/curriculum/parser';
 
 const ingestPayloadSchema = z.object({
   source: z.enum(['WEBHOOK', 'MANUAL', 'SCHEDULED', 'API']).optional().default('WEBHOOK'),
@@ -95,26 +98,9 @@ export const POST = withApiHandler(async (req, ctx) => {
         // Process each file in the batch
         for (const file of batchFiles) {
           try {
-            // Skip files without content
-            if (!file.content || file.content.trim().length === 0) {
-              logger.warn('Skipping file with no content', { path: file.path });
-              failedFiles++;
-              errors.push(`${file.path}: No content`);
-              continue;
-            }
-            
-            // Extract metadata with defaults
-            const metadata = file.metadata || {};
-            const subject = metadata.subject || 'MATH';
-            const gradeLevel = metadata.gradeLevel || 0;
-            const standardCodes = Array.isArray(metadata.standardCodes) 
-              ? metadata.standardCodes 
-              : [];
-            
-            // Chunk the file content
-            const chunks = chunkText(file.content, 512, 50);
-            
-            if (chunks.length === 0) {
+            const parsedChunks = await parseCurriculumFile(file);
+
+            if (parsedChunks.length === 0) {
               logger.warn('No chunks generated for file', { path: file.path });
               failedFiles++;
               errors.push(`${file.path}: No chunks generated`);
@@ -123,40 +109,22 @@ export const POST = withApiHandler(async (req, ctx) => {
             
             logger.debug('Generated chunks for file', {
               path: file.path,
-              chunkCount: chunks.length,
+              chunkCount: parsedChunks.length,
             });
             
             // Generate embeddings for all chunks
-            const embeddings = await generateEmbeddings(chunks);
+            const embeddings = await generateEmbeddings(parsedChunks.map((chunk) => chunk.text));
             
-            if (embeddings.length !== chunks.length) {
-              throw new Error(`Embedding count mismatch: ${embeddings.length} vs ${chunks.length}`);
+            if (embeddings.length !== parsedChunks.length) {
+              throw new Error(`Embedding count mismatch: ${embeddings.length} vs ${parsedChunks.length}`);
             }
             
             // Prepare vectors for Pinecone with comprehensive metadata
-            const vectors = chunks.map((chunk, i) => {
-              // Generate unique ID for each chunk
-              const cleanPath = file.path.replace(/[^a-zA-Z0-9-_]/g, '-');
-              const vectorId = `${cleanPath}-chunk-${i}`;
-              
-              const vectorMetadata: CurriculumMetadata = {
-                filename: file.path,
-                documentType: 'curriculum',
-                subject: subject,
-                gradeLevel: gradeLevel,
-                standardCodes: standardCodes,
-                chunkIndex: i,
-                totalChunks: chunks.length,
-                text: chunk,
-                // Include optional metadata if provided
-                ...(metadata.course && { course: metadata.course }),
-                ...(metadata.module && { module: metadata.module }),
-              };
-              
+            const vectors = parsedChunks.map((chunk, i) => {
               return {
-                id: vectorId,
+                id: chunk.id,
                 values: embeddings[i],
-                metadata: vectorMetadata,
+                metadata: chunk.metadata,
               };
             });
             
@@ -165,7 +133,7 @@ export const POST = withApiHandler(async (req, ctx) => {
             
             logger.info('Successfully processed file', {
               path: file.path,
-              chunks: chunks.length,
+              chunks: parsedChunks.length,
               vectorIds: vectors.length,
             });
             

--- a/src/lib/__tests__/vector-search.test.ts
+++ b/src/lib/__tests__/vector-search.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { searchCurriculum, formatCurriculumContext } from '@/lib/vector-search';
+import * as embeddings from '@/lib/embeddings';
+import * as pinecone from '@/lib/pinecone';
+
+vi.mock('@/lib/embeddings', () => ({
+  generateEmbedding: vi.fn(),
+}));
+
+vi.mock('@/lib/pinecone', () => ({
+  queryVectors: vi.fn(),
+}));
+
+describe('vector-search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OPENAI_API_KEY = 'test-key';
+    process.env.PINECONE_API_KEY = 'test-key';
+  });
+
+  it('retrieves curriculum-aligned contexts with metadata filtering', async () => {
+    vi.mocked(embeddings.generateEmbedding).mockResolvedValue([0.1, 0.2]);
+    vi.mocked(pinecone.queryVectors).mockResolvedValue([
+      {
+        id: 'a',
+        score: 0.91,
+        metadata: {
+          text: 'Use manipulatives to model equivalent fractions before symbolic notation.',
+          filename: 'docs/docs/04-grade-bands/3-5/part-2.md',
+          subject: 'MATH',
+          gradeLevel: 4,
+          standardCodes: ['CCSS.MATH.CONTENT.4.NF.A.1'],
+        },
+      },
+      {
+        id: 'b',
+        score: 0.2,
+        metadata: {
+          text: 'Out-of-band result',
+          filename: 'docs/docs/04-grade-bands/9-12/part-4.md',
+          subject: 'MATH',
+          gradeLevel: 10,
+          standardCodes: [],
+        },
+      },
+    ] as any);
+
+    const results = await searchCurriculum('How do I teach equivalent fractions in grade 4?', {
+      subject: 'MATH',
+      gradeLevel: 4,
+      minScore: 0.35,
+      topK: 5,
+    });
+
+    expect(embeddings.generateEmbedding).toHaveBeenCalled();
+    expect(pinecone.queryVectors).toHaveBeenCalledWith([0.1, 0.2], expect.objectContaining({
+      subject: 'MATH',
+      gradeLevel: 4,
+      topK: 5,
+    }));
+    expect(results).toHaveLength(1);
+    expect(results[0].text).toContain('equivalent fractions');
+
+    const context = formatCurriculumContext(results);
+    expect(context).toContain('Relevant Curriculum Content');
+    expect(context).toContain('CCSS.MATH.CONTENT.4.NF.A.1');
+  });
+
+  it('uses cache for repeated retrieval on same query/filter set', async () => {
+    vi.mocked(embeddings.generateEmbedding).mockResolvedValue([0.5, 0.6]);
+    vi.mocked(pinecone.queryVectors).mockResolvedValue([
+      {
+        id: 'cached-1',
+        score: 0.88,
+        metadata: {
+          text: 'Anchor SEL reflection prompts to restorative routines.',
+          filename: 'docs/docs/03-5rs-framework/reflect.md',
+          subject: 'INTERDISCIPLINARY',
+          gradeLevel: 7,
+          standardCodes: [],
+        },
+      },
+    ] as any);
+
+    const options = { subject: 'INTERDISCIPLINARY', gradeLevel: 7, topK: 3 };
+    const first = await searchCurriculum('How can I run reflection circles after conflict?', options);
+    const second = await searchCurriculum('How can I run reflection circles after conflict?', options);
+
+    expect(first).toEqual(second);
+    expect(pinecone.queryVectors).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/curriculum/parser.test.ts
+++ b/src/lib/curriculum/parser.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { parseCurriculumFile } from '@/lib/curriculum/parser';
+
+describe('curriculum parser', () => {
+  it('parses markdown into chunks and infers metadata for filtering', async () => {
+    const chunks = await parseCurriculumFile({
+      path: 'docs/docs/04-grade-bands/3-5/part-1.md',
+      content: '# Fraction Foundations\n\nStudents compare fractions with visual models.',
+      metadata: { subject: 'MATH', standardCodes: ['CCSS.MATH.CONTENT.3.NF.A.1'] },
+    });
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0].metadata.gradeLevel).toBe(4);
+    expect(chunks[0].metadata.subject).toBe('MATH');
+    expect(chunks[0].metadata.course).toBe('3-5');
+    expect(chunks[0].metadata.module).toBe('part-1');
+  });
+});

--- a/src/lib/curriculum/parser.ts
+++ b/src/lib/curriculum/parser.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { chunkMarkdown, chunkText } from '@/lib/embeddings';
+
+export interface CurriculumFileInput {
+  path: string;
+  content?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ParsedCurriculumChunk {
+  id: string;
+  text: string;
+  metadata: {
+    filename: string;
+    documentType: 'curriculum';
+    subject: string;
+    gradeLevel: number;
+    standardCodes: string[];
+    chunkIndex: number;
+    totalChunks: number;
+    text: string;
+    course?: string;
+    module?: string;
+  };
+}
+
+const GRADE_MAP: Record<string, number> = {
+  'K-2': 1,
+  '3-5': 4,
+  '6-8': 7,
+  '9-12': 10,
+};
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, '/');
+}
+
+function inferGradeLevel(filePath: string, fallback?: number): number {
+  const normalized = normalizePath(filePath);
+  const match = normalized.match(/(?:grade-bands|04-grade-bands)\/(K-2|3-5|6-8|9-12)/i);
+  if (match?.[1]) {
+    return GRADE_MAP[match[1]] ?? fallback ?? 0;
+  }
+  return fallback ?? 0;
+}
+
+function inferCourseAndModule(filePath: string): { course?: string; module?: string } {
+  const parts = normalizePath(filePath).split('/').filter(Boolean);
+  const course = parts.length >= 2 ? parts[parts.length - 2] : undefined;
+  const moduleFile = parts.at(-1);
+  const module = moduleFile?.replace(/\.md$/i, '');
+  return { course, module };
+}
+
+function inferSubject(metadata: Record<string, unknown>, content: string): string {
+  if (typeof metadata.subject === 'string' && metadata.subject.trim()) {
+    return metadata.subject.toUpperCase();
+  }
+
+  const scan = content.toLowerCase();
+  if (scan.includes('mathematics') || scan.includes('math')) return 'MATH';
+  if (scan.includes('science')) return 'SCIENCE';
+  if (scan.includes('english language arts') || scan.includes('ela')) return 'ELA';
+  if (scan.includes('social studies')) return 'SOCIAL_STUDIES';
+  return 'INTERDISCIPLINARY';
+}
+
+async function resolveContent(file: CurriculumFileInput): Promise<string> {
+  if (typeof file.content === 'string') {
+    return file.content;
+  }
+
+  const repoRoot = process.cwd();
+  const absolutePath = path.isAbsolute(file.path)
+    ? file.path
+    : path.join(repoRoot, file.path);
+  return fs.readFile(absolutePath, 'utf8');
+}
+
+export async function parseCurriculumFile(
+  file: CurriculumFileInput,
+): Promise<ParsedCurriculumChunk[]> {
+  const content = (await resolveContent(file)).trim();
+  const metadata = file.metadata ?? {};
+
+  if (!content) {
+    return [];
+  }
+
+  const subject = inferSubject(metadata, content);
+  const gradeLevel = inferGradeLevel(file.path, typeof metadata.gradeLevel === 'number' ? metadata.gradeLevel : 0);
+  const standardCodes = Array.isArray(metadata.standardCodes)
+    ? metadata.standardCodes.filter((code): code is string => typeof code === 'string')
+    : [];
+
+  const inferred = inferCourseAndModule(file.path);
+  const course = typeof metadata.course === 'string' ? metadata.course : inferred.course;
+  const module = typeof metadata.module === 'string' ? metadata.module : inferred.module;
+
+  const chunks = file.path.endsWith('.md')
+    ? chunkMarkdown(content, 512)
+    : chunkText(content, 512, 50);
+
+  const cleanPath = file.path.replace(/[^a-zA-Z0-9-_]/g, '-');
+
+  return chunks.map((chunk, index) => ({
+    id: `${cleanPath}-chunk-${index}`,
+    text: chunk,
+    metadata: {
+      filename: file.path,
+      documentType: 'curriculum',
+      subject,
+      gradeLevel,
+      standardCodes,
+      chunkIndex: index,
+      totalChunks: chunks.length,
+      text: chunk,
+      ...(course ? { course } : {}),
+      ...(module ? { module } : {}),
+    },
+  }));
+}

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -5,6 +5,16 @@ const EMBEDDING_MODEL = 'text-embedding-3-small';
 const EMBEDDING_DIMENSIONS = 1536;
 
 let openaiClient: OpenAI | null = null;
+const embeddingCache = new Map<string, number[]>();
+
+function hashText(text: string): string {
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = ((hash << 5) - hash) + text.charCodeAt(i);
+    hash |= 0;
+  }
+  return String(hash);
+}
 
 function getOpenAI(): OpenAI {
   if (!openaiClient) {
@@ -28,13 +38,21 @@ export async function generateEmbedding(text: string): Promise<number[]> {
     throw new Error('Cannot generate embedding for empty text');
   }
 
+  const cacheKey = `${EMBEDDING_MODEL}:${hashText(cleaned)}`;
+  const cached = embeddingCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const response = await openai.embeddings.create({
     model: EMBEDDING_MODEL,
     input: cleaned,
     dimensions: EMBEDDING_DIMENSIONS,
   });
 
-  return response.data[0].embedding;
+  const embedding = response.data[0].embedding;
+  embeddingCache.set(cacheKey, embedding);
+  return embedding;
 }
 
 /**
@@ -44,38 +62,65 @@ export async function generateEmbedding(text: string): Promise<number[]> {
 export async function generateEmbeddings(
   texts: string[],
 ): Promise<number[][]> {
+  if (texts.length === 0) {
+    return [];
+  }
+
   const openai = getOpenAI();
 
   const cleaned = texts.map(t => t.replace(/\n+/g, ' ').trim());
-  const nonEmpty = cleaned.filter(t => t.length > 0);
-  if (nonEmpty.length === 0) {
+  if (cleaned.every(t => t.length === 0)) {
     return [];
+  }
+
+  const results: number[][] = new Array(cleaned.length);
+  const uncached: { index: number; text: string; cacheKey: string }[] = [];
+
+  cleaned.forEach((text, index) => {
+    if (!text) {
+      results[index] = new Array(EMBEDDING_DIMENSIONS).fill(0);
+      return;
+    }
+    const cacheKey = `${EMBEDDING_MODEL}:${hashText(text)}`;
+    const cached = embeddingCache.get(cacheKey);
+    if (cached) {
+      results[index] = cached;
+      return;
+    }
+    uncached.push({ index, text, cacheKey });
+  });
+
+  if (uncached.length === 0) {
+    return results;
   }
 
   // Process in batches of 100 to stay well within limits
   const batchSize = 100;
-  const allEmbeddings: number[][] = [];
 
-  for (let i = 0; i < nonEmpty.length; i += batchSize) {
-    const batch = nonEmpty.slice(i, i + batchSize);
+  for (let i = 0; i < uncached.length; i += batchSize) {
+    const batch = uncached.slice(i, i + batchSize);
     const response = await openai.embeddings.create({
       model: EMBEDDING_MODEL,
-      input: batch,
+      input: batch.map(item => item.text),
       dimensions: EMBEDDING_DIMENSIONS,
     });
 
     const sorted = response.data.sort((a, b) => a.index - b.index);
-    allEmbeddings.push(...sorted.map(d => d.embedding));
+    sorted.forEach((entry, batchIndex) => {
+      const target = batch[batchIndex];
+      embeddingCache.set(target.cacheKey, entry.embedding);
+      results[target.index] = entry.embedding;
+    });
 
-    if (i + batchSize < nonEmpty.length) {
+    if (i + batchSize < uncached.length) {
       logger.debug('Embedding batch progress', {
         processed: i + batch.length,
-        total: nonEmpty.length,
+        total: uncached.length,
       });
     }
   }
 
-  return allEmbeddings;
+  return results;
 }
 
 /**

--- a/src/lib/pinecone.ts
+++ b/src/lib/pinecone.ts
@@ -76,6 +76,9 @@ export async function queryVectors(
     topK?: number;
     subject?: string;
     gradeLevel?: number;
+    course?: string;
+    module?: string;
+    documentType?: string;
   } = {},
 ): Promise<{
   id: string;
@@ -83,7 +86,7 @@ export async function queryVectors(
   metadata: CurriculumMetadata;
 }[]> {
   const index = getIndex();
-  const { topK = 5, subject, gradeLevel } = options;
+  const { topK = 5, subject, gradeLevel, course, module, documentType = 'curriculum' } = options;
 
   // Build metadata filter
   const filter: Record<string, unknown> = {};
@@ -92,6 +95,15 @@ export async function queryVectors(
   }
   if (gradeLevel) {
     filter.gradeLevel = { $eq: gradeLevel };
+  }
+  if (course) {
+    filter.course = { $eq: course };
+  }
+  if (module) {
+    filter.module = { $eq: module };
+  }
+  if (documentType) {
+    filter.documentType = { $eq: documentType };
   }
 
   const results = await index.query({

--- a/src/lib/vector-search.ts
+++ b/src/lib/vector-search.ts
@@ -2,6 +2,9 @@ import { generateEmbedding } from '@/lib/embeddings';
 import { queryVectors, type CurriculumMetadata } from '@/lib/pinecone';
 import { logger } from '@/lib/logger';
 
+const SEARCH_CACHE_TTL_MS = 5 * 60 * 1000;
+const searchCache = new Map<string, { expiresAt: number; value: SearchResult[] }>();
+
 export interface SearchResult {
   text: string;
   score: number;
@@ -20,11 +23,13 @@ export async function searchCurriculum(
   options: {
     subject?: string;
     gradeLevel?: number;
+    course?: string;
+    module?: string;
     topK?: number;
     minScore?: number;
   } = {},
 ): Promise<SearchResult[]> {
-  const { topK = 5, minScore = 0.3 } = options;
+  const { topK = 5, minScore = 0.3, subject, gradeLevel, course, module } = options;
 
   // Check that required services are configured
   if (!process.env.OPENAI_API_KEY || !process.env.PINECONE_API_KEY) {
@@ -33,12 +38,20 @@ export async function searchCurriculum(
   }
 
   try {
+    const cacheKey = JSON.stringify({ query, topK, minScore, subject, gradeLevel, course, module });
+    const cached = searchCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
     const embedding = await generateEmbedding(query);
 
     const results = await queryVectors(embedding, {
       topK,
-      subject: options.subject,
-      gradeLevel: options.gradeLevel,
+      subject,
+      gradeLevel,
+      course,
+      module,
     });
 
     const filtered = results
@@ -56,6 +69,11 @@ export async function searchCurriculum(
       query: query.substring(0, 80),
       resultsFound: results.length,
       afterFilter: filtered.length,
+    });
+
+    searchCache.set(cacheKey, {
+      value: filtered,
+      expiresAt: Date.now() + SEARCH_CACHE_TTL_MS,
     });
 
     return filtered;


### PR DESCRIPTION
### Motivation

- Provide a production-ready curriculum ingestion pipeline that converts curriculum files into Pinecone vectors with rich metadata (course/module/grade/standards) for reliable RAG retrieval.
- Replace placeholder embeddings/retrieval in the chat flow with real embeddings + filtered vector search to improve relevance and safety of context injection.

### Description

- Added a curriculum parser (`src/lib/curriculum/parser.ts`) that reads file content (or loads from disk), chunks markdown/JSON/text, infers subject/grade/course/module and emits Pinecone-ready chunk objects with stable IDs.
- Wired ingestion endpoint to use the parser and the embedding service: `/api/ingest` now parses files, generates batch embeddings via OpenAI (`text-embedding-3-small`), and upserts vectors with full curriculum metadata (`src/app/api/ingest/route.ts`, `src/lib/pinecone.ts`).
- Implemented embedding caching and robust batch handling in `src/lib/embeddings.ts` to avoid repeated API calls and preserve input ordering for batch requests.
- Expanded Pinecone query filtering to include `documentType`, `course`, and `module` in addition to `subject` and `gradeLevel` to enable precise metadata-constrained retrieval (`src/lib/pinecone.ts`).
- Replaced the chat endpoint's placeholder retrieval with the new `searchCurriculum` + `formatCurriculumContext` layer, adding score thresholding and injecting formatted curriculum context into the system prompt (`src/app/api/chat/route.ts`, `src/lib/vector-search.ts`).
- Added in-memory caching for curriculum search results and tests for parser behavior, retrieval filtering, and cache reuse (`src/lib/__tests__/vector-search.test.ts`, `src/lib/curriculum/parser.test.ts`, `src/lib/pinecone/__tests__/embeddings.test.ts`).

### Testing

- Ran unit tests with Vitest: `npx vitest --run src/lib/__tests__/vector-search.test.ts src/lib/curriculum/parser.test.ts src/lib/pinecone/__tests__/embeddings.test.ts`, which passed (all tests in those files succeeded).
- Ran TypeScript check: `npx tsc --noEmit`; this failed due to pre-existing unrelated TypeScript errors outside the scope of this PR (examples: `src/hooks/useChat.ts` and some test typing issues), but these errors are not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988535afa50832a95534fe0fcb6ccb2)