### PR TITLE
chore: route Vercel build through npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:e2e:report": "playwright show-report",
     "rag:create-index": "tsx scripts/create-pinecone-index.ts",
     "test:integration": "vitest tests/integration --run",
-    "compliance:check": "node scripts/validate-compliance.mjs"
+    "compliance:check": "node scripts/validate-compliance.mjs",
+    "vercel-build": "prisma generate && next build"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,23 +1,40 @@
 {
   "framework": "nextjs",
-  "buildCommand": "npx prisma generate && next build",
+  "buildCommand": "npm run vercel-build",
   "installCommand": "npm ci",
-  "regions": ["iad1"],
+  "regions": [
+    "iad1"
+  ],
   "crons": [],
   "headers": [
     {
       "source": "/api/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "no-store, max-age=0" }
+        {
+          "key": "Cache-Control",
+          "value": "no-store, max-age=0"
+        }
       ]
     },
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(self), geolocation=()" }
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(self), geolocation=()"
+        }
       ]
     }
   ]


### PR DESCRIPTION
### Motivation
- Centralize the deployment build command in `package.json` so CI/Vercel resolves local binaries via npm scripts.
- Avoid invoking `next build` directly from Vercel config to reduce environment-specific "next: not found" failures.

### Description
- Added a `vercel-build` script to `package.json` that runs `prisma generate && next build`.
- Updated `vercel.json` to use `npm run vercel-build` as the `buildCommand` so Vercel runs the npm script.
- Applied minor JSON formatting adjustments in `vercel.json` for consistency.

### Testing
- Validated that `package.json` and `vercel.json` parse as JSON with `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'));JSON.parse(require('fs').readFileSync('vercel.json','utf8'));console.log('json ok')"`, which succeeded.
- Attempted `npm ci` and `npm run build` in this environment but package install/build remained long-running so a full local build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698853bea750832aa4b2bb15a37b6f15)