### PR TITLE
Add node-cache dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "svix": "^1.84.1",
     "tailwind-merge": "^2.5.0",
     "zod": "^3.23.0",
-    "zustand": "^4.5.0"
+    "zustand": "^4.5.0",
+    "node-cache": "^5.1.2"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
### Motivation
- The ingestion and chat API routes import `node-cache`, which was not listed in `package.json` and would cause runtime "Cannot find module 'node-cache'" errors during deployment.

### Description
- Add `node-cache` pinned to `^5.1.2` to the `dependencies` section of `package.json` so the module resolves in production.

### Testing
- Attempted to run `npm install node-cache@5.1.2 --save`, `npm run lint`, `npm test`, and `npm run test:e2e`; all checks failed in this environment due to npm registry access being blocked (`403 Forbidden`) or missing project binaries (`next`, `vitest`, `playwright`) because dependencies were not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c4fb6864832abec6bafd539a12ae)