### PR TITLE
Harden backend API contracts, rate limiting, and observability

### DIFF
--- a/src/app/api/assessments/context/__tests__/route.test.ts
+++ b/src/app/api/assessments/context/__tests__/route.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockAuth = vi.fn();
+const mockDb = {
+  user: { findUnique: vi.fn() },
+  session: { findFirst: vi.fn() },
+};
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: mockAuth }));
+vi.mock('@/lib/db', () => ({ db: mockDb }));
+vi.mock('@/lib/logger', () => ({ logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock('@/lib/monitoring', () => ({ captureError: vi.fn() }));
+
+describe('GET /api/assessments/context', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns standardized 401 error when unauthenticated', async () => {
+    const { GET } = await import('../route');
+    mockAuth.mockReturnValue({ userId: null });
+
+    const response = await GET(new NextRequest('http://localhost/api/assessments/context'));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.code).toBe('AUTHENTICATION_ERROR');
+    expect(body.requestId).toBeTruthy();
+  });
+
+  it('returns learner context when authenticated', async () => {
+    const { GET } = await import('../route');
+    mockAuth.mockReturnValue({ userId: 'clerk_1' });
+    mockDb.user.findUnique.mockResolvedValue({ student: { id: 'stu_1', gradeLevel: 6 } });
+    mockDb.session.findFirst.mockResolvedValue({ id: 'sess_1', subject: 'MATH' });
+
+    const response = await GET(new NextRequest('http://localhost/api/assessments/context'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.studentId).toBe('stu_1');
+    expect(body.data.sessionId).toBe('sess_1');
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('60');
+  });
+});

--- a/src/app/api/assessments/context/route.ts
+++ b/src/app/api/assessments/context/route.ts
@@ -1,17 +1,23 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { db } from '@/lib/db';
+import { withApiHandler } from '@/lib/api-handler';
+import { AuthenticationError, NotFoundError } from '@/lib/api-errors';
 
-export async function GET() {
+export const GET = withApiHandler(async () => {
   const { userId: clerkId } = auth();
-  if (!clerkId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!clerkId) {
+    throw new AuthenticationError();
+  }
 
   const user = await db.user.findUnique({
     where: { clerkUserId: clerkId },
     include: { student: true },
   });
 
-  if (!user?.student) return NextResponse.json({ error: 'Student profile not found' }, { status: 404 });
+  if (!user?.student) {
+    throw new NotFoundError('Student profile not found');
+  }
 
   const latestSession = await db.session.findFirst({
     where: { studentId: user.student.id, endedAt: null },
@@ -26,4 +32,4 @@ export async function GET() {
       sessionId: latestSession?.id ?? null,
     },
   });
-}
+}, { rateLimit: { windowMs: 60_000, max: 60 } });

--- a/src/app/api/assessments/review/__tests__/route.test.ts
+++ b/src/app/api/assessments/review/__tests__/route.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockAuth = vi.fn();
+const mockDb = {
+  user: { findUnique: vi.fn() },
+  assessment: { findMany: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
+};
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: mockAuth }));
+vi.mock('@/lib/db', () => ({ db: mockDb }));
+vi.mock('@/lib/logger', () => ({ logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock('@/lib/monitoring', () => ({ captureError: vi.fn() }));
+
+describe('POST /api/assessments/review', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns standardized validation error contract', async () => {
+    const { POST } = await import('../route');
+    mockAuth.mockReturnValue({ userId: 'clerk_1' });
+    mockDb.user.findUnique.mockResolvedValue({ id: 'u1', tenantId: 't1', role: 'EDUCATOR' });
+
+    const response = await POST(
+      new NextRequest('http://localhost/api/assessments/review', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ assessmentId: 'a1', rubricScore: 200, comments: 'x' }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.code).toBe('VALIDATION_ERROR');
+    expect(body.requestId).toBeTruthy();
+  });
+
+  it('returns standardized auth error contract', async () => {
+    const { GET } = await import('../route');
+    mockAuth.mockReturnValue({ userId: null });
+
+    const response = await GET(new NextRequest('http://localhost/api/assessments/review'));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.code).toBe('AUTHENTICATION_ERROR');
+  });
+});

--- a/src/app/api/assessments/review/route.ts
+++ b/src/app/api/assessments/review/route.ts
@@ -1,7 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
-import { db } from '@/lib/db';
+import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { db } from '@/lib/db';
+import { withApiHandler } from '@/lib/api-handler';
+import {
+  AuthenticationError,
+  ForbiddenError,
+  NotFoundError,
+} from '@/lib/api-errors';
 
 const reviewSchema = z.object({
   assessmentId: z.string().min(1),
@@ -9,15 +15,27 @@ const reviewSchema = z.object({
   comments: z.string().min(1).max(2000),
 });
 
-export async function GET() {
+const ALLOWED_ROLES = ['EDUCATOR', 'SCHOOL_ADMIN', 'DISTRICT_ADMIN', 'PLATFORM_ADMIN'] as const;
+
+async function requireReviewer() {
   const { userId: clerkId } = auth();
-  if (!clerkId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!clerkId) {
+    throw new AuthenticationError();
+  }
 
   const user = await db.user.findUnique({ where: { clerkUserId: clerkId } });
-  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
-  if (!['EDUCATOR', 'SCHOOL_ADMIN', 'DISTRICT_ADMIN', 'PLATFORM_ADMIN'].includes(user.role)) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  if (!user) {
+    throw new NotFoundError('User not found');
   }
+  if (!ALLOWED_ROLES.includes(user.role as typeof ALLOWED_ROLES[number])) {
+    throw new ForbiddenError();
+  }
+
+  return user;
+}
+
+export const GET = withApiHandler(async () => {
+  const user = await requireReviewer();
 
   const assessments = await db.assessment.findMany({
     where: {
@@ -48,25 +66,11 @@ export async function GET() {
       studentName: `${assessment.session.student.user.firstName} ${assessment.session.student.user.lastName}`,
     })),
   });
-}
+}, { rateLimit: { windowMs: 60_000, max: 60 } });
 
-export async function POST(request: NextRequest) {
-  const { userId: clerkId } = auth();
-  if (!clerkId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-  const user = await db.user.findUnique({ where: { clerkUserId: clerkId } });
-  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
-  if (!['EDUCATOR', 'SCHOOL_ADMIN', 'DISTRICT_ADMIN', 'PLATFORM_ADMIN'].includes(user.role)) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  let body;
-  try {
-    body = reviewSchema.parse(await request.json());
-  } catch (error) {
-    const message = error instanceof z.ZodError ? error.errors.map((e) => e.message).join(', ') : 'Invalid request';
-    return NextResponse.json({ error: message }, { status: 400 });
-  }
+export const POST = withApiHandler(async (request) => {
+  const user = await requireReviewer();
+  const body = reviewSchema.parse(await request.json());
 
   const assessment = await db.assessment.findUnique({
     where: { id: body.assessmentId },
@@ -74,8 +78,9 @@ export async function POST(request: NextRequest) {
   });
 
   if (!assessment || assessment.session.tenantId !== user.tenantId) {
-    return NextResponse.json({ error: 'Assessment not found' }, { status: 404 });
+    throw new NotFoundError('Assessment not found');
   }
+
 
   const metadata = (assessment.metadata as Record<string, unknown> | null) ?? {};
   const updated = await db.assessment.update({
@@ -94,4 +99,4 @@ export async function POST(request: NextRequest) {
   });
 
   return NextResponse.json({ data: updated, message: 'Assessment reviewed successfully' });
-}
+}, { rateLimit: { windowMs: 60_000, max: 30 } });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -27,15 +27,7 @@ export const POST = withApiHandler(async (req, { requestId }) => {
     throw new AuthenticationError();
   }
 
-  let body;
-  try {
-    body = chatRequestSchema.parse(await req.json());
-  } catch (err: unknown) {
-    const message = err instanceof z.ZodError
-      ? err.errors.map((e: { message: string }) => e.message).join(', ')
-      : 'Invalid request';
-    return new Response(JSON.stringify({ error: message }), { status: 400 });
-  }
+  const body = chatRequestSchema.parse(await req.json());
 
   const user = await db.user.findUnique({
     where: { clerkUserId: clerkId },

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,16 +1,15 @@
-import { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 import { renderPrometheusMetrics, getMetricsSnapshot } from '@/lib/api/metrics';
+import { withApiHandler } from '@/lib/api-handler';
 
-export async function GET(req: NextRequest) {
+export const GET = withApiHandler(async (req) => {
   const format = req.nextUrl.searchParams.get('format');
 
   if (format === 'json') {
-    return new Response(JSON.stringify(getMetricsSnapshot()), {
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return NextResponse.json(getMetricsSnapshot());
   }
 
   return new Response(renderPrometheusMetrics(), {
     headers: { 'Content-Type': 'text/plain; version=0.0.4' },
   });
-}
+}, { rateLimit: { windowMs: 60_000, max: 120 } });

--- a/src/app/api/sessions/[sessionId]/route.ts
+++ b/src/app/api/sessions/[sessionId]/route.ts
@@ -59,15 +59,7 @@ export const PATCH = withApiHandler(async (req, ctx) => {
     throw new AuthenticationError();
   }
 
-  let body;
-  try {
-    body = updateSessionSchema.parse(await req.json());
-  } catch (err: unknown) {
-    const message = err instanceof z.ZodError
-      ? err.errors.map((e: { message: string }) => e.message).join(', ')
-      : 'Invalid request';
-    return NextResponse.json({ error: message }, { status: 400 });
-  }
+  const body = updateSessionSchema.parse(await req.json());
 
   const session = await db.session.findUnique({
     where: { id: sessionId },

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -35,6 +35,6 @@ export const POST = withApiHandler(async (req) => {
 
     return NextResponse.json({ received: true });
   } catch {
-    return NextResponse.json({ error: 'Invalid webhook payload.' }, { status: 400 });
+    throw new ValidationError('Invalid webhook payload.');
   }
 });

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -85,7 +85,7 @@ export const POST = withApiHandler(async (req, { requestId }) => {
     const body = await req.text();
     const timestampAge = Math.abs(Date.now() / 1000 - Number(svixTimestamp));
     if (!Number.isFinite(timestampAge) || timestampAge > 300) {
-      return NextResponse.json({ error: 'Invalid webhook timestamp' }, { status: 401 });
+      throw new AuthenticationError('Invalid webhook timestamp');
     }
 
     const isValid = verifySvixSignature({
@@ -97,7 +97,7 @@ export const POST = withApiHandler(async (req, { requestId }) => {
     });
 
     if (!isValid) {
-      return NextResponse.json({ error: 'Invalid webhook signature' }, { status: 401 });
+      throw new AuthenticationError('Invalid webhook signature');
     }
 
     event = JSON.parse(body) as ClerkWebhookEvent;

--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -22,11 +22,11 @@ import { z } from 'zod';
 import {
   AppError,
   RateLimitError,
-  ValidationError,
 } from '@/lib/api-errors';
-import { checkRateLimit, type RateLimitConfig } from '@/lib/rate-limit';
+import { checkRateLimit, type RateLimitConfig, type RateLimitResult } from '@/lib/rate-limit';
 import { logger } from '@/lib/logger';
 import { captureError } from '@/lib/monitoring';
+import { incrementMetric, observeLatency } from '@/lib/api/metrics';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -108,13 +108,20 @@ export function withApiHandler(
     const method = req.method;
     const pathname = req.nextUrl.pathname;
 
+    incrementMetric('api_requests_total');
+    incrementMetric(`api_requests_${method.toLowerCase()}_total`);
+
     // --- Rate limiting ---------------------------------------------------
+    let rateLimitResult: RateLimitResult | null = null;
     if (options.rateLimit) {
       const ip = resolveClientIp(req);
       const key = `${pathname}:${ip}`;
       const result = checkRateLimit(key, options.rateLimit);
+      rateLimitResult = result;
 
       if (!result.allowed) {
+        incrementMetric('api_rate_limit_exceeded_total');
+        incrementMetric(`api_rate_limit_exceeded_${method.toLowerCase()}_total`);
         logger.warn('Rate limit exceeded', {
           requestId,
           pathname,
@@ -160,6 +167,14 @@ export function withApiHandler(
       }
 
       const durationMs = Date.now() - startTime;
+      observeLatency(pathname, durationMs);
+
+      if (options.rateLimit && rateLimitResult) {
+        response.headers.set('X-RateLimit-Limit', String(options.rateLimit.max));
+        response.headers.set('X-RateLimit-Remaining', String(rateLimitResult.remaining));
+        response.headers.set('X-RateLimit-Reset', String(rateLimitResult.resetAt));
+      }
+
       logger.info('API response', {
         requestId,
         method,
@@ -174,6 +189,9 @@ export function withApiHandler(
 
       // ---- Known application errors ------------------------------------
       if (error instanceof AppError) {
+        incrementMetric('api_errors_total');
+        incrementMetric(`api_errors_${error.code.toLowerCase()}_total`);
+        observeLatency(pathname, durationMs);
         logger.warn('API error', {
           requestId,
           method,
@@ -202,6 +220,9 @@ export function withApiHandler(
 
       // ---- Zod validation errors (thrown outside handler's own catch) ---
       if (error instanceof z.ZodError) {
+        incrementMetric('api_errors_total');
+        incrementMetric('api_errors_validation_error_total');
+        observeLatency(pathname, durationMs);
         const details = error.errors.map((e) => ({
           path: e.path.join('.'),
           message: e.message,
@@ -226,6 +247,9 @@ export function withApiHandler(
 
       // ---- Unexpected errors -------------------------------------------
       captureError(error, { requestId, route: pathname });
+      incrementMetric('api_errors_total');
+      incrementMetric('api_errors_internal_error_total');
+      observeLatency(pathname, durationMs);
       logger.error('Unhandled API error', error, {
         requestId,
         method,


### PR DESCRIPTION
### Motivation
- Provide a single, consistent API error contract and observability for high-traffic endpoints to simplify integration, error handling, and monitoring. 
- Ensure rate-limited routes expose standard rate limit headers and emit metrics for requests, errors, and latency so operators can detect hotspots.

### Description
- Extended the shared wrapper `withApiHandler` to increment request/error counters and observe per-route latency via `incrementMetric` and `observeLatency`, and to attach `X-RateLimit-*` headers on successful responses for rate-limited routes (`src/lib/api-handler.ts`).
- Replaced ad-hoc response handling in several endpoints so they rely on the centralized error contract (`AppError` / Zod mapping), and wrapped those handlers with `withApiHandler`: key endpoints include `src/app/api/assessments/review/route.ts`, `src/app/api/assessments/context/route.ts`, `src/app/api/metrics/route.ts`, `src/app/api/chat/route.ts`, `src/app/api/sessions/[sessionId]/route.ts`, `src/app/api/webhooks/clerk/route.ts`, and `src/app/api/stripe/webhook/route.ts`.
- Standardized webhook validation paths to throw `AuthenticationError` / `ValidationError` instead of returning ad-hoc `NextResponse` error payloads to ensure consistent JSON error envelopes.
- Added endpoint-level tests to validate standardized contracts and rate-limit header behavior for assessments context and review routes (`src/app/api/assessments/context/__tests__/route.test.ts`, `src/app/api/assessments/review/__tests__/route.test.ts`).

### Testing
- Ran `git diff --check` with no whitespace errors reported, and committed the changes successfully. 
- Attempted to run targeted unit/integration tests via Vitest (`npm test -- --run ...`) but the test runner was not available in the environment (`sh: 1: vitest: not found`) so suites were not executed. 
- Attempted dependency install with `npm ci` to enable running tests but the installation did not complete in this session, blocking automated test execution; new tests were added but remain unrun until CI or a local dev environment runs `npm ci && npm test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c56ed6bc832a9eb65d3803b63598)