### PR TITLE
Add parallel task-agent runner and fix lint/typecheck blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ npm run test
 
 # Run end-to-end tests
 npm run test:e2e
+
+# Launch parallel task agents (lint + typecheck + unit + integration + build)
+npm run ops:parallel
+
+# Launch only selected task agents
+npm run ops:parallel -- lint build
 ```
 
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "rag:create-index": "tsx scripts/create-pinecone-index.ts",
     "test:integration": "vitest tests/integration --run",
     "compliance:check": "node scripts/validate-compliance.mjs",
-    "vercel-build": "prisma generate && next build"
+    "vercel-build": "prisma generate && next build",
+    "ops:parallel": "node ./scripts/parallel-task-agents.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.0",

--- a/scripts/parallel-task-agents.mjs
+++ b/scripts/parallel-task-agents.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+
+const DEFAULT_TASKS = [
+  { name: 'lint', cmd: 'npm', args: ['run', 'lint'] },
+  { name: 'typecheck', cmd: 'npx', args: ['tsc', '--noEmit'] },
+  { name: 'unit-tests', cmd: 'npm', args: ['test', '--', '--run', '--passWithNoTests'] },
+  { name: 'integration-tests', cmd: 'npm', args: ['run', 'test:integration'] },
+  { name: 'build', cmd: 'npm', args: ['run', 'build'] },
+];
+
+const SELECTABLE_TASKS = new Map(DEFAULT_TASKS.map((task) => [task.name, task]));
+
+function parseSelectedTasks() {
+  const requested = process.argv
+    .slice(2)
+    .map((arg) => arg.trim())
+    .filter(Boolean);
+
+  if (requested.length === 0) {
+    return DEFAULT_TASKS;
+  }
+
+  const invalid = requested.filter((name) => !SELECTABLE_TASKS.has(name));
+  if (invalid.length > 0) {
+    console.error(`Unknown task(s): ${invalid.join(', ')}`);
+    console.error(`Available tasks: ${Array.from(SELECTABLE_TASKS.keys()).join(', ')}`);
+    process.exit(2);
+  }
+
+  return requested.map((name) => SELECTABLE_TASKS.get(name));
+}
+
+function runTask(task) {
+  return new Promise((resolve) => {
+    const child = spawn(task.cmd, task.args, {
+      shell: false,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const prefix = `[${task.name}]`;
+
+    child.stdout.on('data', (chunk) => {
+      process.stdout.write(`${prefix} ${chunk}`);
+    });
+
+    child.stderr.on('data', (chunk) => {
+      process.stderr.write(`${prefix} ${chunk}`);
+    });
+
+    child.on('close', (code) => {
+      resolve({ task: task.name, code: code ?? 1, child });
+    });
+
+    child.on('error', (error) => {
+      console.error(`${prefix} Failed to start: ${error.message}`);
+      resolve({ task: task.name, code: 1, child });
+    });
+  });
+}
+
+async function main() {
+  const tasks = parseSelectedTasks();
+
+  console.log(`Launching ${tasks.length} parallel task agent(s): ${tasks.map((t) => t.name).join(', ')}`);
+
+  const taskRuns = tasks.map((task) => runTask(task));
+  const results = await Promise.all(taskRuns);
+  const failed = results.filter((result) => result.code !== 0);
+
+  console.log('\nParallel task summary:');
+  for (const result of results) {
+    const status = result.code === 0 ? 'PASS' : `FAIL (${result.code})`;
+    console.log(`- ${result.task}: ${status}`);
+  }
+
+  if (failed.length > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -48,19 +48,6 @@ export function useChat(): UseChatReturn {
     }
   }, [setPhase]);
 
-  const updatePhaseInternal = useCallback(async (sid: string, phase: string) => {
-    setPhase(phase as Parameters<typeof setPhase>[0]);
-    try {
-      await fetch(`/api/sessions/${sid}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ currentPhase: phase }),
-      });
-    } catch {
-      // Silently fail phase persistence -- local state is updated
-    }
-  }, [setPhase]);
-
   const sendMessage = useCallback(async (content: string) => {
     if (!sessionId || !content.trim()) return;
 
@@ -201,7 +188,7 @@ export function useChat(): UseChatReturn {
     sessionId, messages, currentPhase, regulationLevel,
     addMessage, startStreamingMessage, appendToStreamingMessage,
     finishStreamingMessage, setLoading, addSignal, triggerIntervention,
-    updatePhaseInternal,
+    updatePhaseInternal, setPhase, setRegulationLevel,
   ]);
 
   const createSession = useCallback(async (

--- a/src/lib/__tests__/api-handler.test.ts
+++ b/src/lib/__tests__/api-handler.test.ts
@@ -25,7 +25,7 @@ vi.mock('@/lib/monitoring', () => ({
 
 function makeRequest(
   path = '/api/test',
-  init?: RequestInit & { headers?: Record<string, string> },
+  init?: ConstructorParameters<typeof NextRequest>[1],
 ) {
   const url = `http://localhost${path}`;
   return new NextRequest(url, init);
@@ -141,6 +141,7 @@ describe('withApiHandler', () => {
 
       const handler = withApiHandler(async () => {
         z.object({ name: z.string() }).parse({});
+        return NextResponse.json({ ok: true });
       });
 
       const res = await handler(makeRequest());

--- a/src/lib/curriculum/parser.ts
+++ b/src/lib/curriculum/parser.ts
@@ -49,8 +49,8 @@ function inferCourseAndModule(filePath: string): { course?: string; module?: str
   const parts = normalizePath(filePath).split('/').filter(Boolean);
   const course = parts.length >= 2 ? parts[parts.length - 2] : undefined;
   const moduleFile = parts.at(-1);
-  const module = moduleFile?.replace(/\.md$/i, '');
-  return { course, module };
+  const moduleName = moduleFile?.replace(/\.md$/i, '');
+  return { course, module: moduleName };
 }
 
 function inferSubject(metadata: Record<string, unknown>, content: string): string {
@@ -96,7 +96,7 @@ export async function parseCurriculumFile(
 
   const inferred = inferCourseAndModule(file.path);
   const course = typeof metadata.course === 'string' ? metadata.course : inferred.course;
-  const module = typeof metadata.module === 'string' ? metadata.module : inferred.module;
+  const moduleName = typeof metadata.module === 'string' ? metadata.module : inferred.module;
 
   const chunks = file.path.endsWith('.md')
     ? chunkMarkdown(content, 512)
@@ -117,7 +117,7 @@ export async function parseCurriculumFile(
       totalChunks: chunks.length,
       text: chunk,
       ...(course ? { course } : {}),
-      ...(module ? { module } : {}),
+      ...(moduleName ? { module: moduleName } : {}),
     },
   }));
 }

--- a/tests/integration/api/health.route.integration.test.ts
+++ b/tests/integration/api/health.route.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
 
 vi.mock('@/lib/db', () => ({
   db: {
@@ -9,7 +10,7 @@ vi.mock('@/lib/db', () => ({
 describe('GET /api/health', () => {
   it('returns a healthy status when db query succeeds', async () => {
     const { GET } = await import('@/app/api/health/route');
-    const response = await GET();
+    const response = await GET(new NextRequest('http://localhost/api/health'));
     const data = await response.json();
 
     expect(response.status).toBe(200);


### PR DESCRIPTION
### Motivation
- Provide a single, parallelized entrypoint to run linting, type-checking, tests, and build steps to speed CI/developer feedback cycles.
- Unblock failing static checks in the repo so CI and local validation can run cleanly.

### Description
- Add `scripts/parallel-task-agents.mjs` which launches selectable task agents in parallel and returns a combined pass/fail summary, and wire it to an npm script `ops:parallel` in `package.json`.
- Document usage for full and selective parallel runs in `README.md` and add the `ops:parallel` invocation examples.
- Fix a duplicate declaration and callback dependency issues in `useChat` by removing the second `updatePhaseInternal` and updating hook dependencies to satisfy lint/typecheck rules.
- Rename the local `module` variable to `moduleName` in `src/lib/curriculum/parser.ts` to avoid Next.js `no-assign-module-variable` lint errors while preserving output metadata.
- Tighten test helper typing in `src/lib/__tests__/api-handler.test.ts` to use `ConstructorParameters<typeof NextRequest>[1]` and ensure the Zod-error test returns a `NextResponse` as expected by `withApiHandler`.
- Update `tests/integration/api/health.route.integration.test.ts` to pass a `NextRequest` to the route handler so the integration test matches the route signature.

### Testing
- Ran `npm run ops:parallel -- lint typecheck` and both `lint` and `typecheck` completed successfully (PASS).
- Ran the targeted unit/integration tests with `npm test -- --run src/lib/__tests__/api-handler.test.ts tests/integration/api/health.route.integration.test.ts` and the test suite passed (`2` files, `15` tests passed).
- Changes were committed and recorded; the repository now includes the `ops:parallel` script and the code fixes needed for clean static validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c98eb4ec832a8db9d11f6d72fa9f)