### PR TITLE
Fix Vercel build failures in API handler and monitoring modules

### DIFF
--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -100,7 +100,7 @@ export function withApiHandler(
 ) {
   return async (
     req: NextRequest,
-    routeContext?: { params?: Promise<Record<string, string>> },
+    routeContext: { params: Promise<Record<string, string>> },
   ): Promise<NextResponse | Response> => {
     const requestId =
       req.headers.get('x-request-id') || crypto.randomUUID();
@@ -148,9 +148,7 @@ export function withApiHandler(
     // --- Resolve params ---------------------------------------------------
     let params: Record<string, string> = {};
     try {
-      if (routeContext?.params) {
-        params = await routeContext.params;
-      }
+      params = await routeContext.params;
     } catch {
       // params resolution failed – leave empty
     }

--- a/src/lib/monitoring.ts
+++ b/src/lib/monitoring.ts
@@ -9,23 +9,13 @@ interface ErrorContext {
 
 /**
  * Report an error to the monitoring service.
- * When Sentry is configured (NEXT_PUBLIC_SENTRY_DSN set), errors are sent there.
- * Always logs via structured logger as a fallback.
+ *
+ * This project currently uses structured logging as the primary telemetry sink.
+ * Keeping this utility centralised makes it easy to re-introduce a vendor SDK
+ * (for example Sentry) in one place without touching route handlers.
  */
 export function captureError(error: unknown, context?: ErrorContext) {
   logger.error('Captured error', error, context);
-
-  // Sentry integration — dynamic import to avoid bundling if not configured
-  if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
-    import('@sentry/nextjs')
-      .then((Sentry) => {
-        if (context) Sentry.setContext('app', context);
-        Sentry.captureException(error);
-      })
-      .catch(() => {
-        // Sentry not installed — that's fine, we already logged
-      });
-  }
 }
 
 /**
@@ -33,12 +23,4 @@ export function captureError(error: unknown, context?: ErrorContext) {
  */
 export function trackEvent(name: string, data?: Record<string, unknown>) {
   logger.info(`Event: ${name}`, data);
-
-  if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
-    import('@sentry/nextjs')
-      .then((Sentry) => {
-        Sentry.addBreadcrumb({ category: 'event', message: name, data, level: 'info' });
-      })
-      .catch(() => {});
-  }
 }


### PR DESCRIPTION
### Motivation
- Vercel production builds were failing due to a hard dependency on `@sentry/nextjs` being pulled into the bundle and a mismatched App Router route handler type in the API wrapper.
- The goal is to ensure builds succeed without requiring optional vendor SDKs and to match Next.js 15 route export typing expectations.

### Description
- Removed dynamic imports of `@sentry/nextjs` from `src/lib/monitoring.ts` and made `captureError` / `trackEvent` rely on the project's structured `logger` only so the SDK is not required at build time.
- Updated the `withApiHandler` return signature in `src/lib/api-handler.ts` to accept `routeContext: { params: Promise<Record<string, string>> }` (non-optional) and simplified parameter resolution to `params = await routeContext.params;` to satisfy Next.js App Router type checking.
- Kept observability helpers centralized to make re-introducing a vendor SDK straightforward without touching route handlers.

### Testing
- Ran `npx prisma generate` which completed successfully and generated the Prisma client.
- Ran `npx next build` after the changes and the production build completed successfully (one pre-existing ESLint warning remains). 
- `npm ci` was attempted in this environment but failed with `403 Forbidden` from the npm registry and is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988cb9f22cc832a801a3ebb032d08f4)