### PR TITLE
Wire landing and dashboard links to functional routes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,9 +5,9 @@ import { siteConfig } from '@/config/site';
 import { studentNavItems } from '@/config/navigation';
 
 const rolePortals = [
-  { label: 'Educator Dashboard', href: '/educator/dashboard' },
-  { label: 'Parent Dashboard', href: '/parent/dashboard' },
-  { label: 'Admin Dashboard', href: '/admin/dashboard' },
+  { label: 'Educator Dashboard', href: '/educator/students' },
+  { label: 'Parent Dashboard', href: '/students/demo-student/assessments' },
+  { label: 'Admin Dashboard', href: '/admin/ingest' },
 ] as const;
 
 export default function HomePage() {

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -8,7 +8,6 @@ export const studentNavItems = [
 ] as const;
 
 export const educatorNavItems = [
-  { label: 'Dashboard', href: '/educator/dashboard', icon: 'layout-dashboard' },
   { label: 'Students', href: '/educator/students', icon: 'users' },
   { label: 'Classes', href: '/educator/classes', icon: 'school' },
   { label: 'Reports', href: '/educator/reports', icon: 'file-text' },
@@ -16,10 +15,10 @@ export const educatorNavItems = [
 ] as const;
 
 export const parentNavItems = [
-  { label: 'Dashboard', href: '/parent/dashboard', icon: 'home' },
+  { label: 'Child Assessments', href: '/students/demo-student/assessments', icon: 'progress' },
   { label: 'Settings', href: '/parent/settings', icon: 'settings' },
 ] as const;
 
 export const adminNavItems = [
-  { label: 'Dashboard', href: '/admin/dashboard', icon: 'layout-dashboard' },
+  { label: 'Ingestion Control', href: '/admin/ingest', icon: 'shield-check' },
 ] as const;


### PR DESCRIPTION
### Motivation
- Landing page role-portal buttons and some dashboard tiles pointed to non-operable dashboard endpoints, leaving users on dead-end pages.
- Update navigation to surface working workflows so users can reach actionable pages for educator, parent, and admin roles.

### Description
- Changed landing page role portal targets in `src/app/page.tsx` to point to usable pages: Educator → `/educator/students`, Parent → `/students/demo-student/assessments`, Admin → `/admin/ingest`.
- Updated role navigation in `src/config/navigation.ts` so educator cards list actionable sections (`Students`, `Classes`, `Reports`, `Compliance`), parent links include `Child Assessments` and `Settings`, and admin links to `Ingestion Control` (`/admin/ingest`).

### Testing
- Ran `npm run lint` and received only existing unrelated warnings in `src/hooks/useChat.ts`, with no new lint errors from these changes.
- Started the dev server and executed a headless Playwright script to capture the landing page, which completed successfully and produced a screenshot of the updated portal links.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e25a414c832aa9c80c7b9d11864a)