### PR TITLE
Wire landing page hero CTAs to real destinations (auth-aware primary action)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,31 @@ const rolePortals = [
   { label: 'Admin Dashboard', href: '/admin/dashboard' },
 ] as const;
 
+const authEnabled = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
+
+const heroActions = [
+  {
+    label: authEnabled ? 'Get Started' : 'Start Learning',
+    href: authEnabled ? '/sign-up' : '/learn',
+    className: 'rounded-lg bg-primary-600 px-6 py-3 text-white transition-colors hover:bg-primary-700',
+  },
+  {
+    label: 'Sign In',
+    href: '/sign-in',
+    className: 'rounded-lg border border-primary-600 px-6 py-3 text-primary-600 transition-colors hover:bg-primary-50',
+  },
+  {
+    label: 'Methodology',
+    href: '/methodology',
+    className: 'rounded-lg border border-neutral-300 px-6 py-3 text-neutral-700 transition-colors hover:bg-neutral-100',
+  },
+  {
+    label: 'Contact',
+    href: '/contact',
+    className: 'rounded-lg border border-neutral-300 px-6 py-3 text-neutral-700 transition-colors hover:bg-neutral-100',
+  },
+] as const;
+
 export default function HomePage() {
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-8 py-14">
@@ -18,19 +43,12 @@ export default function HomePage() {
         <h1 className="mb-4 text-4xl font-bold text-primary-800">{siteConfig.name}</h1>
         <p className="mb-6 text-xl text-secondary-700">{siteConfig.tagline}</p>
         <p className="mx-auto mb-10 max-w-3xl text-lg text-neutral-600">{siteConfig.description}</p>
-        <div className="flex gap-4 justify-center">
-          <Link
-            href="/sign-up"
-            className="rounded-lg bg-primary-600 px-6 py-3 text-white transition-colors hover:bg-primary-700"
-          >
-            Get Started
-          </Link>
-          <Link
-            href="/methodology"
-            className="rounded-lg border border-primary-600 px-6 py-3 text-primary-600 transition-colors hover:bg-primary-50"
-          >
-            Learn More
-          </Link>
+        <div className="flex flex-wrap justify-center gap-4">
+          {heroActions.map((action) => (
+            <Link key={action.href} href={action.href} className={action.className}>
+              {action.label}
+            </Link>
+          ))}
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- The landing hero contained sparse/static buttons that were not consistently wired to application routes. 
- Provide clear, immediate entry points for users by surfacing `Sign In`, `Methodology`, and `Contact` from the hero. 
- Prevent dead-end auth flows in non-auth environments by making the primary CTA environment-aware using the Clerk publishable key (`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`).

### Description
- Added an `authEnabled` flag computed from `process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` to detect whether Clerk auth is configured. 
- Introduced a `heroActions` array and rendered the hero CTAs dynamically via `heroActions.map(...)` in `src/app/page.tsx`, replacing the previous hard-coded links. 
- Made the primary CTA route to `/sign-up` when auth is enabled and fall back to `/learn` when it is not. 
- Updated the hero layout to use `flex-wrap` and added explicit actions for `Sign In`, `Methodology`, and `Contact` to improve responsiveness and discoverability.

### Testing
- Ran `npm run lint` which completed successfully with an existing unrelated ESLint warning in `src/app/regulate/page.tsx`. 
- Executed an automated Playwright script that loaded the home page and captured a screenshot of the updated hero, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e2ae535c832ab12954ff5edc5c9c)