### PR TITLE
Fix learn-session start: show error and clear on interaction

### DIFF
--- a/src/app/learn/page.tsx
+++ b/src/app/learn/page.tsx
@@ -35,6 +35,7 @@ export default function LearnPage() {
 
   const [showEndDialog, setShowEndDialog] = useState(false);
   const [completedSummary, setCompletedSummary] = useState<SessionSummaryData | null>(null);
+  const [startError, setStartError] = useState<string | null>(null);
 
   const {
     sendMessage,
@@ -50,8 +51,12 @@ export default function LearnPage() {
 
   const handleStartSession = useCallback(
     async (selectedSubject: Subject, selectedMode: EngagementMode) => {
+      setStartError(null);
       setCompletedSummary(null);
-      await createSession(selectedSubject, selectedMode);
+      const createdSessionId = await createSession(selectedSubject, selectedMode);
+      if (!createdSessionId) {
+        setStartError('We could not start your session. Please try again in a moment.');
+      }
     },
     [createSession],
   );
@@ -121,7 +126,12 @@ export default function LearnPage() {
   if (!sessionId || !subject) {
     return (
       <main className="min-h-screen px-6 py-12">
-        <SessionSetup onStart={handleStartSession} isLoading={isLoading} />
+        <SessionSetup
+          onStart={handleStartSession}
+          isLoading={isLoading}
+          startError={startError}
+          onClearError={() => setStartError(null)}
+        />
       </main>
     );
   }

--- a/src/components/learn/SessionSetup.tsx
+++ b/src/components/learn/SessionSetup.tsx
@@ -10,6 +10,8 @@ type EngagementMode = 'FORWARD' | 'REVERSE' | 'ERROR_ANALYSIS' | 'MULTIPLE_PATHW
 interface SessionSetupProps {
   onStart: (subject: Subject, mode: EngagementMode) => void;
   isLoading: boolean;
+  startError?: string | null;
+  onClearError?: () => void;
 }
 
 interface RecentSession {
@@ -75,7 +77,7 @@ function formatRelativeTime(dateStr: string): string {
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
-export function SessionSetup({ onStart, isLoading }: SessionSetupProps) {
+export function SessionSetup({ onStart, isLoading, startError, onClearError }: SessionSetupProps) {
   const [selectedSubject, setSelectedSubject] = useState<Subject | null>(null);
   const [selectedMode, setSelectedMode] = useState<EngagementMode>('FORWARD');
   const [recentSessions, setRecentSessions] = useState<RecentSession[]>([]);
@@ -121,7 +123,10 @@ export function SessionSetup({ onStart, isLoading }: SessionSetupProps) {
             ([key, subject]) => (
               <button
                 key={key}
-                onClick={() => setSelectedSubject(key)}
+                onClick={() => {
+                  onClearError?.();
+                  setSelectedSubject(key);
+                }}
                 className={`rounded-lg border-2 p-4 text-left transition-all ${
                   selectedSubject === key
                     ? 'border-current shadow-md'
@@ -147,7 +152,10 @@ export function SessionSetup({ onStart, isLoading }: SessionSetupProps) {
             ([key, mode]) => (
               <button
                 key={key}
-                onClick={() => setSelectedMode(key)}
+                onClick={() => {
+                  onClearError?.();
+                  setSelectedMode(key);
+                }}
                 className={`rounded-lg border-2 p-3 text-left transition-all ${
                   selectedMode === key
                     ? 'border-primary-600 bg-primary-50 shadow-sm'
@@ -169,12 +177,24 @@ export function SessionSetup({ onStart, isLoading }: SessionSetupProps) {
         <Button
           size="lg"
           disabled={!selectedSubject || isLoading}
-          onClick={() => selectedSubject && onStart(selectedSubject, selectedMode)}
+          onClick={() => {
+            onClearError?.();
+            if (selectedSubject) {
+              onStart(selectedSubject, selectedMode);
+            }
+          }}
           className="px-12"
         >
           {isLoading ? 'Starting...' : 'Begin Session'}
         </Button>
       </div>
+
+
+      {startError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {startError}
+        </div>
+      )}
 
       {/* Recent Sessions */}
       {!historyLoading && recentSessions.length > 0 && (
@@ -188,6 +208,7 @@ export function SessionSetup({ onStart, isLoading }: SessionSetupProps) {
                 <button
                   key={session.id}
                   onClick={() => {
+                    onClearError?.();
                     setSelectedSubject(session.subject);
                     setSelectedMode(session.engagementMode);
                   }}


### PR DESCRIPTION
### Motivation
- Users reported that tapping **Begin Session** produced no visible result when session creation failed, so the setup UX needed explicit feedback and clearer action bindings.

### Description
- Add `startError` state to the `/learn` page and update `handleStartSession` to check `createSession(...)` return value and set a user-facing error when creation fails. 
- Pass `startError` and `onClearError` props from `LearnPage` into `SessionSetup` so the setup component can display and clear errors.
- Extend `SessionSetup` props and wire subject buttons, mode buttons, the Begin button, and recent-session picker to call `onClearError` when interacted with so staled errors are cleared on user action.
- Render an inline alert in `SessionSetup` to display start failures immediately to the user.

### Testing
- Ran `npm run lint`, which completed successfully (an unrelated warning remains in `src/app/regulate/page.tsx`).
- Started the dev server (`npm run dev`) and used Playwright to load `/learn`, which returned `200` and produced a screenshot showing the updated setup UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698900111a84832a9324fef8f741618c)