### PR TITLE
Add privacy-safe LLM pipeline, immutable audit chain, and tenant RBAC hardening

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -21,6 +21,14 @@ const isApiRoute = (pathname: string) => pathname.startsWith("/api/");
 const isWebhookRoute = (pathname: string) => pathname.startsWith("/api/webhooks/");
 const isMutatingMethod = (method: string) => ["POST", "PUT", "PATCH", "DELETE"].includes(method);
 
+const applyTransportSecurityHeaders = (response: NextResponse) => {
+  response.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("X-Frame-Options", "DENY");
+  return response;
+};
+
+
 const getClientIp = (request: NextRequest) => {
   const forwardedFor = request.headers.get("x-forwarded-for");
   if (forwardedFor) {
@@ -91,19 +99,26 @@ const enforceCsrfForApi = (request: NextRequest) => {
 };
 
 export default clerkMiddleware((auth, req) => {
+  const proto = req.headers.get("x-forwarded-proto");
+  if (proto && proto !== "https") {
+    return NextResponse.json({ error: "HTTPS required" }, { status: 426 });
+  }
+
   const rateLimitResponse = enforceRateLimit(req);
   if (rateLimitResponse) {
-    return rateLimitResponse;
+    return applyTransportSecurityHeaders(rateLimitResponse);
   }
 
   const csrfResponse = enforceCsrfForApi(req);
   if (csrfResponse) {
-    return csrfResponse;
+    return applyTransportSecurityHeaders(csrfResponse);
   }
 
   if (!isPublicRoute(req)) {
     auth().protect();
   }
+
+  return applyTransportSecurityHeaders(NextResponse.next());
 });
 
 export const config = {

--- a/prisma/migrations/20260209090000_audit_chain_and_privacy/migration.sql
+++ b/prisma/migrations/20260209090000_audit_chain_and_privacy/migration.sql
@@ -1,0 +1,13 @@
+-- Add immutable hash-chain support for audit logs
+ALTER TABLE "AuditLog"
+ADD COLUMN     "previousHash" TEXT,
+ADD COLUMN     "chainHash" TEXT;
+
+UPDATE "AuditLog"
+SET "chainHash" = md5("id" || ':' || EXTRACT(EPOCH FROM "timestamp")::text)
+WHERE "chainHash" IS NULL;
+
+ALTER TABLE "AuditLog"
+ALTER COLUMN "chainHash" SET NOT NULL;
+
+CREATE UNIQUE INDEX "AuditLog_chainHash_key" ON "AuditLog"("chainHash");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -554,15 +554,17 @@ enum AIFeature {
 // ═══════════════════════════════════════════════════════════════
 
 model AuditLog {
-  id         String   @id @default(cuid())
-  tenantId   String
-  userId     String
-  action     String
-  resource   String
-  resourceId String?
-  metadata   Json?
-  ipAddress  String?
-  timestamp  DateTime @default(now())
+  id           String   @id @default(cuid())
+  tenantId     String
+  userId       String
+  action       String
+  resource     String
+  resourceId   String?
+  metadata     Json?
+  ipAddress    String?
+  previousHash String?
+  chainHash    String   @unique
+  timestamp    DateTime @default(now())
 
   @@index([tenantId])
   @@index([tenantId, timestamp])

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -9,6 +9,8 @@ import { enforceUsageLimits, UsageLimitError } from '@/lib/usage-limits';
 import { detectDysregulation, updateRegulationLevel } from '@/lib/regulation/detector';
 import { analyzeThinkingQuality } from '@/lib/trace/tracker';
 import { z } from 'zod';
+import { anonymizeForLlmWithMap, reattachPii } from '@/lib/privacy';
+import { appendImmutableAuditLog } from '@/lib/audit';
 
 const chatRequestSchema = z.object({
   sessionId: z.string().min(1),
@@ -166,11 +168,13 @@ export async function POST(req: NextRequest) {
   });
 
   // Build message history for API call
+  const piiTokenMap: Record<string, string> = {};
   const apiMessages = session.messages.map(m => ({
     role: (m.role === 'USER' ? 'user' : 'assistant') as 'user' | 'assistant',
-    content: m.content,
+    content: anonymizeForLlmWithMap(m.content, piiTokenMap).sanitizedText,
   }));
-  apiMessages.push({ role: 'user', content: body.message });
+  const anonymizedInput = anonymizeForLlmWithMap(body.message, piiTokenMap);
+  apiMessages.push({ role: 'user', content: anonymizedInput.sanitizedText });
 
   // Filter consecutive same-role messages (Anthropic requires alternating)
   const filteredMessages: { role: 'user' | 'assistant'; content: string }[] = [];
@@ -192,7 +196,7 @@ export async function POST(req: NextRequest) {
   const stream = await anthropic.messages.stream({
     model: AI_MODELS.primary,
     max_tokens: 1024,
-    system: systemPrompt,
+    system: anonymizeForLlmWithMap(systemPrompt, piiTokenMap).sanitizedText,
     messages: filteredMessages,
   });
 
@@ -205,22 +209,25 @@ export async function POST(req: NextRequest) {
         for await (const event of stream) {
           if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
             fullText += event.delta.text;
-            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ text: event.delta.text })}\n\n`));
+            const deidentifiedChunk = reattachPii(event.delta.text, anonymizedInput.tokenMap);
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ text: deidentifiedChunk })}\n\n`));
           }
         }
+
+        const restoredAssistantText = reattachPii(fullText, anonymizedInput.tokenMap);
 
         // Save assistant message
         await db.message.create({
           data: {
             sessionId: session.id,
             role: 'ASSISTANT',
-            content: fullText,
+            content: restoredAssistantText,
           },
         });
 
         // Track thinking quality with TRACE protocol (async, don't block response)
         if (body.message.length > MIN_MESSAGE_LENGTH_FOR_TRACE) {
-          analyzeThinkingQuality(body.message, fullText)
+          analyzeThinkingQuality(body.message, restoredAssistantText)
             .then(async (traceData) => {
               if (!traceData) return;
 
@@ -301,6 +308,18 @@ export async function POST(req: NextRequest) {
           },
         });
 
+
+        await appendImmutableAuditLog({
+          tenantId: user.tenantId,
+          userId: user.id,
+          action: 'LLM_CHAT_COMPLETED',
+          resource: 'Session',
+          resourceId: session.id,
+          metadata: {
+            anonymizationTokens: Object.keys(anonymizedInput.tokenMap).length,
+            inputLength: body.message.length,
+          },
+        });
         controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true })}\n\n`));
         controller.close();
       } catch (err) {

--- a/src/app/api/compliance/consent/route.ts
+++ b/src/app/api/compliance/consent/route.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 import { requireUser } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { canManageMinorConsent, isConsentStatusTransitionAllowed } from '@/lib/compliance';
+import { appendImmutableAuditLog } from '@/lib/audit';
+import { assertTenantAccess } from '@/lib/rbac';
 
 const updateConsentSchema = z.object({
   studentUserId: z.string().min(1),
@@ -68,7 +70,9 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Student not found' }, { status: 404 });
     }
 
-    if (student.tenantId !== actor.tenantId) {
+    try {
+      assertTenantAccess(actor.role, actor.tenantId, student.tenantId);
+    } catch {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
@@ -98,19 +102,17 @@ export async function POST(request: Request) {
       },
     });
 
-    await db.auditLog.create({
-      data: {
-        tenantId: student.tenantId,
-        userId: actor.id,
-        action: 'CONSENT_STATUS_UPDATED',
-        resource: 'User',
-        resourceId: student.id,
-        metadata: {
-          previousStatus: currentStatus,
-          nextStatus: payload.consentStatus,
-          method: payload.method,
-          notes: payload.notes,
-        },
+    await appendImmutableAuditLog({
+      tenantId: student.tenantId,
+      userId: actor.id,
+      action: 'CONSENT_STATUS_UPDATED',
+      resource: 'User',
+      resourceId: student.id,
+      metadata: {
+        previousStatus: currentStatus,
+        nextStatus: payload.consentStatus,
+        method: payload.method,
+        notes: payload.notes,
       },
     });
 

--- a/src/app/api/educator/compliance/route.ts
+++ b/src/app/api/educator/compliance/route.ts
@@ -3,6 +3,8 @@ import { auth } from '@clerk/nextjs/server';
 import { db } from '@/lib/db';
 import { z } from 'zod';
 import type { Prisma } from '@prisma/client';
+import { appendImmutableAuditLog } from '@/lib/audit';
+import { assertTenantAccess } from '@/lib/rbac';
 
 const accommodationSchema = z.object({
   studentId: z.string().min(1),
@@ -36,7 +38,12 @@ export async function GET(req: NextRequest) {
       where: { id: studentId },
       include: { user: { select: { tenantId: true } } },
     });
-    if (!student || student.user.tenantId !== user.tenantId) {
+    if (!student) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    try {
+      assertTenantAccess(user.role, user.tenantId, student.user.tenantId);
+    } catch {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
@@ -103,15 +110,13 @@ export async function POST(req: NextRequest) {
   });
 
   // Audit log
-  await db.auditLog.create({
-    data: {
-      tenantId: user.tenantId,
-      userId: user.id,
-      action: 'CREATE_ACCOMMODATION',
-      resource: 'IepAccommodation',
-      resourceId: accommodation.id,
-      metadata: { studentId: body.studentId, type: body.type },
-    },
+  await appendImmutableAuditLog({
+    tenantId: user.tenantId,
+    userId: user.id,
+    action: 'CREATE_ACCOMMODATION',
+    resource: 'IepAccommodation',
+    resourceId: accommodation.id,
+    metadata: { studentId: body.studentId, type: body.type },
   });
 
   return NextResponse.json({ data: accommodation }, { status: 201 });

--- a/src/lib/__tests__/privacy.test.ts
+++ b/src/lib/__tests__/privacy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { anonymizeForLlm, decryptAtRest, encryptAtRest, reattachPii } from '@/lib/privacy';
+
+describe('privacy controls', () => {
+  beforeEach(() => {
+    vi.stubEnv('DATA_ENCRYPTION_KEY', Buffer.alloc(32, 1).toString('base64'));
+  });
+
+  it('encrypts and decrypts payloads for at-rest storage', () => {
+    const payload = encryptAtRest('sensitive student record');
+    const plaintext = decryptAtRest(payload);
+    expect(plaintext).toBe('sensitive student record');
+  });
+
+  it('anonymizes PII before LLM calls and can reattach tokens', () => {
+    const input = 'Student Jane Doe has IEP goal: extra time on tests.';
+    const { sanitizedText, tokenMap } = anonymizeForLlm(input);
+
+    expect(sanitizedText).not.toContain('Jane Doe');
+    expect(sanitizedText).not.toContain('IEP goal: extra time on tests');
+
+    const restored = reattachPii(sanitizedText, tokenMap);
+    expect(restored).toContain('Jane Doe');
+    expect(restored).toContain('IEP goal');
+  });
+});

--- a/src/lib/__tests__/rbac.test.ts
+++ b/src/lib/__tests__/rbac.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { assertTenantAccess, canAccessTenant } from '@/lib/rbac';
+
+describe('RBAC district isolation', () => {
+  it('allows platform admins to cross tenant boundaries', () => {
+    expect(canAccessTenant('PLATFORM_ADMIN', 't1', 't2')).toBe(true);
+  });
+
+  it('blocks district-scoped roles from crossing tenant boundaries', () => {
+    expect(canAccessTenant('DISTRICT_ADMIN', 'district-a', 'district-b')).toBe(false);
+  });
+
+  it('throws for forbidden cross-district access', () => {
+    expect(() => assertTenantAccess('EDUCATOR', 'district-a', 'district-b')).toThrow(/cross-district/);
+  });
+});

--- a/src/lib/__tests__/schema.test.ts
+++ b/src/lib/__tests__/schema.test.ts
@@ -250,6 +250,8 @@ describe('Prisma schema — AI usage & compliance', () => {
     expect(fields).toContain('resource');
     expect(fields).toContain('resourceId');
     expect(fields).toContain('ipAddress');
+    expect(fields).toContain('previousHash');
+    expect(fields).toContain('chainHash');
     expect(fields).toContain('timestamp');
   });
 });

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,0 +1,55 @@
+import crypto from 'crypto';
+import { db } from '@/lib/db';
+
+export type AuditWriteInput = {
+  tenantId: string;
+  userId: string;
+  action: string;
+  resource: string;
+  resourceId?: string | null;
+  metadata?: unknown;
+  ipAddress?: string | null;
+};
+
+function hashAuditRecord(payload: {
+  tenantId: string;
+  userId: string;
+  action: string;
+  resource: string;
+  resourceId?: string | null;
+  metadata?: unknown;
+  timestamp: Date;
+  previousHash?: string | null;
+}): string {
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(payload))
+    .digest('hex');
+}
+
+export async function appendImmutableAuditLog(input: AuditWriteInput) {
+  const previous = await db.auditLog.findFirst({
+    where: { tenantId: input.tenantId },
+    orderBy: { timestamp: 'desc' },
+    select: { chainHash: true },
+  });
+
+  const timestamp = new Date();
+  const previousHash = previous?.chainHash ?? null;
+  const chainHash = hashAuditRecord({ ...input, timestamp, previousHash });
+
+  return db.auditLog.create({
+    data: {
+      tenantId: input.tenantId,
+      userId: input.userId,
+      action: input.action,
+      resource: input.resource,
+      resourceId: input.resourceId,
+      metadata: input.metadata as any,
+      ipAddress: input.ipAddress,
+      timestamp,
+      previousHash,
+      chainHash,
+    },
+  });
+}

--- a/src/lib/compliance.ts
+++ b/src/lib/compliance.ts
@@ -60,3 +60,19 @@ export type DataRightsRequestType = 'EXPORT' | 'DELETE';
 export function requiresGuardianForDataRequest(isMinor: boolean, role: UserRole): boolean {
   return isMinor && !canManageMinorConsent(role);
 }
+
+
+export const regulatoryControls = {
+  FERPA: [
+    'Least-privilege access to education records',
+    'Immutable access audit logging for record views and updates',
+  ],
+  COPPA: [
+    'Guardian-managed consent lifecycle for users under 13',
+    'PII minimization before external model processing',
+  ],
+  GDPR: [
+    'Data minimization and purpose limitation',
+    'Deletion/export support through data-rights workflows',
+  ],
+} as const;

--- a/src/lib/privacy.ts
+++ b/src/lib/privacy.ts
@@ -1,0 +1,116 @@
+import crypto from 'crypto';
+
+const ENCRYPTION_ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+function getEncryptionKey(): Buffer {
+  const key = process.env.DATA_ENCRYPTION_KEY;
+  if (!key) {
+    throw new Error('DATA_ENCRYPTION_KEY must be configured for encryption at rest');
+  }
+
+  const raw = Buffer.from(key, 'base64');
+  if (raw.length !== 32) {
+    throw new Error('DATA_ENCRYPTION_KEY must decode to exactly 32 bytes (base64)');
+  }
+
+  return raw;
+}
+
+export type EncryptedPayload = {
+  ciphertext: string;
+  iv: string;
+  authTag: string;
+};
+
+export function encryptAtRest(plaintext: string): EncryptedPayload {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ENCRYPTION_ALGORITHM, getEncryptionKey(), iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    ciphertext: encrypted.toString('base64'),
+    iv: iv.toString('base64'),
+    authTag: authTag.toString('base64'),
+  };
+}
+
+export function decryptAtRest(payload: EncryptedPayload): string {
+  const decipher = crypto.createDecipheriv(
+    ENCRYPTION_ALGORITHM,
+    getEncryptionKey(),
+    Buffer.from(payload.iv, 'base64'),
+    { authTagLength: AUTH_TAG_LENGTH }
+  );
+  decipher.setAuthTag(Buffer.from(payload.authTag, 'base64'));
+
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(payload.ciphertext, 'base64')),
+    decipher.final(),
+  ]);
+
+  return decrypted.toString('utf8');
+}
+
+type PiiTokenMap = Record<string, string>;
+
+const PATTERNS = {
+  studentName: /\b([A-Z][a-z]+\s+[A-Z][a-z]+)\b/g,
+  iepTerm: /\b(IEP\s*(?:goal|plan|details|accommodation)?\s*[:\-]?\s*[^\n,.]{3,120})/gi,
+};
+
+export function anonymizeForLlm(text: string): { sanitizedText: string; tokenMap: PiiTokenMap } {
+  const tokenMap: PiiTokenMap = {};
+  let counter = 1;
+
+  const replaceWithToken = (input: string, regex: RegExp, label: string) =>
+    input.replace(regex, (match) => {
+      if (Object.values(tokenMap).includes(match)) {
+        const existing = Object.entries(tokenMap).find(([, value]) => value === match);
+        return existing ? existing[0] : match;
+      }
+
+      const token = `[${label}_${counter}]`;
+      tokenMap[token] = match;
+      counter += 1;
+      return token;
+    });
+
+  let sanitizedText = text;
+  sanitizedText = replaceWithToken(sanitizedText, PATTERNS.iepTerm, 'IEP_REDACTED');
+  sanitizedText = replaceWithToken(sanitizedText, PATTERNS.studentName, 'STUDENT_REDACTED');
+
+  return { sanitizedText, tokenMap };
+}
+
+export function reattachPii(text: string, tokenMap: PiiTokenMap): string {
+  return Object.entries(tokenMap).reduce((result, [token, value]) => result.split(token).join(value), text);
+}
+
+
+export function anonymizeForLlmWithMap(text: string, tokenMap: Record<string, string>): { sanitizedText: string; tokenMap: Record<string, string> } {
+  let counter = Object.keys(tokenMap).length + 1;
+
+  const replaceWithToken = (input: string, regex: RegExp, label: string) =>
+    input.replace(regex, (match) => {
+      const existing = Object.entries(tokenMap).find(([, value]) => value === match);
+      if (existing) {
+        return existing[0];
+      }
+
+      const token = `[${label}_${counter}]`;
+      tokenMap[token] = match;
+      counter += 1;
+      return token;
+    });
+
+  let sanitizedText = text;
+  sanitizedText = replaceWithToken(sanitizedText, PATTERNS.iepTerm, 'IEP_REDACTED');
+  sanitizedText = replaceWithToken(sanitizedText, PATTERNS.studentName, 'STUDENT_REDACTED');
+  return { sanitizedText, tokenMap };
+}

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -1,0 +1,21 @@
+import type { UserRole } from '@prisma/client';
+
+const districtScopedRoles: UserRole[] = ['EDUCATOR', 'SCHOOL_ADMIN', 'DISTRICT_ADMIN', 'PARENT', 'STUDENT'];
+
+export function canAccessTenant(actorRole: UserRole, actorTenantId: string, resourceTenantId: string): boolean {
+  if (actorRole === 'PLATFORM_ADMIN') {
+    return true;
+  }
+
+  if (districtScopedRoles.includes(actorRole)) {
+    return actorTenantId === resourceTenantId;
+  }
+
+  return false;
+}
+
+export function assertTenantAccess(actorRole: UserRole, actorTenantId: string, resourceTenantId: string): void {
+  if (!canAccessTenant(actorRole, actorTenantId, resourceTenantId)) {
+    throw new Error('Forbidden: cross-district access denied by RBAC policy');
+  }
+}

--- a/tests/integration/api/compliance-consent.test.ts
+++ b/tests/integration/api/compliance-consent.test.ts
@@ -12,6 +12,7 @@ vi.mock('@/lib/db', () => ({
       update: vi.fn(),
     },
     auditLog: {
+      findFirst: vi.fn(),
       create: vi.fn(),
     },
   },
@@ -119,6 +120,7 @@ describe('POST /api/compliance/consent', () => {
       consentStatus: 'GRANTED',
       updatedAt: new Date(),
     } as any);
+    vi.mocked(db.auditLog.findFirst).mockResolvedValueOnce(null as any);
     vi.mocked(db.auditLog.create).mockResolvedValueOnce({} as any);
 
     const { POST } = await import('@/app/api/compliance/consent/route');


### PR DESCRIPTION
### Motivation
- Improve compliance with FERPA/COPPA/GDPR by minimizing PII exposure to external LLMs and strengthening auditability and tenant isolation.
- Ensure data is protected both at rest and in transit, and provide tamper-evident audit records for sensitive actions (consent changes, LLM use, IEP edits).

### Description
- Added a privacy library with AES-256-GCM encryption functions (`encryptAtRest` / `decryptAtRest`) and PII anonymization/reattachment helpers (`anonymizeForLlm`, `anonymizeForLlmWithMap`, `reattachPii`) used to strip PII before LLM calls and restore it on return. (new: `src/lib/privacy.ts`)
- Implemented an append-only, per-tenant audit helper that chains records via `previousHash`/`chainHash` and persists them to `AuditLog`. (new: `src/lib/audit.ts`, schema + migration updates)
- Hardened RBAC with explicit tenant isolation helpers (`canAccessTenant`, `assertTenantAccess`) and integrated tenant assertions into compliance-sensitive endpoints. (new: `src/lib/rbac.ts`, applied in consent and educator endpoints)
- Updated the chat LLM flow to anonymize outbound prompts/messages, send de-identified content to the LLM, reattach PII for streamed responses and persisted assistant messages, and write an immutable audit entry on LLM completion; enforced HTTPS and transport-security headers in middleware; extended compliance guidance constants. (modified: `src/app/api/chat/route.ts`, `src/app/api/compliance/consent/route.ts`, `src/app/api/educator/compliance/route.ts`, `middleware.ts`, `src/lib/compliance.ts`, `prisma/schema.prisma`, `prisma/migrations/20260209090000_audit_chain_and_privacy/migration.sql`)
- Added focused unit/integration tests for the new privacy and RBAC behavior and updated schema tests to assert new audit fields. (new/modified tests: `src/lib/__tests__/privacy.test.ts`, `src/lib/__tests__/rbac.test.ts`, `src/lib/__tests__/schema.test.ts`, `tests/integration/api/compliance-consent.test.ts`)

### Testing
- Added unit tests for privacy and RBAC and updated integration/schema tests, but `npx vitest` runs were blocked by registry access restrictions (npm 403), so tests could not be executed in this environment. (failed)
- Attempted `npm run db:generate` / Prisma generate but the local toolchain was not available (`prisma: not found`) in the sandbox, so migration generation/verification could not be completed here. (failed)
- Static validation performed: project files were updated, migration SQL was created, and tests were adjusted to mock the new audit-chain lookups so CI or a fully provisioned dev environment can run the new tests successfully. (not executed here)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989b15fd49c832aa573d8290276a189)