### PR TITLE
Polish Learn UI accessibility, keyboard navigation, and mobile responsiveness

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,8 +13,8 @@
     color: var(--color-text-primary);
     background-color: var(--color-surface);
     background-image:
-      radial-gradient(circle at 0% 0%, rgba(34, 197, 94, 0.08), transparent 34%),
-      radial-gradient(circle at 100% 0%, rgba(245, 158, 11, 0.08), transparent 30%);
+      radial-gradient(circle at 0% 0%, rgba(34, 197, 94, 0.04), transparent 36%),
+      radial-gradient(circle at 100% 0%, rgba(15, 23, 42, 0.03), transparent 34%);
     line-height: var(--line-height-normal);
   }
 
@@ -25,7 +25,7 @@
 
   /* Focus styles for accessibility */
   :focus-visible {
-    outline: 2px solid var(--color-focus);
+    outline: 3px solid var(--color-focus);
     outline-offset: 2px;
     border-radius: var(--radius-sm);
   }

--- a/src/app/learn/learn-client.tsx
+++ b/src/app/learn/learn-client.tsx
@@ -87,6 +87,12 @@ export function LearnClient({ session, messages, regulationLevel, studentId }: L
 
   return (
     <div className="flex h-screen flex-col">
+      <a
+        href="#learning-chat-log"
+        className="sr-only z-50 rounded-md bg-white px-3 py-2 text-sm font-medium text-neutral-900 focus:not-sr-only focus:absolute focus:left-3 focus:top-3"
+      >
+        Skip to conversation
+      </a>
       {/* Session Header */}
       <SessionHeader
         subject={session.subject}
@@ -97,11 +103,11 @@ export function LearnClient({ session, messages, regulationLevel, studentId }: L
       />
 
       {/* Phase Indicator & Mode Selector */}
-      <div className="border-b bg-white px-4 py-3">
+      <section className="border-b bg-white px-4 py-3" aria-label="Session controls">
         <div className="mx-auto max-w-5xl space-y-3">
           <PhaseIndicator currentPhase={currentPhase} />
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-neutral-700">Engagement Mode:</span>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <span className="text-sm font-medium text-neutral-700">Engagement mode</span>
             <ModeSelector
               currentMode={currentMode}
               onModeChange={handleModeChange}
@@ -109,12 +115,13 @@ export function LearnClient({ session, messages, regulationLevel, studentId }: L
             />
           </div>
         </div>
-      </div>
+      </section>
 
       {/* Chat Interface */}
-      <div className="flex-1 overflow-hidden">
+      <section className="flex-1 overflow-hidden" aria-label="Learning conversation">
         <div className="mx-auto h-full max-w-5xl">
           <ChatInterface
+            id="learning-chat-log"
             sessionId={session.id}
             initialMessages={messages.map((msg) => ({
               ...msg,
@@ -127,7 +134,7 @@ export function LearnClient({ session, messages, regulationLevel, studentId }: L
             onModeChange={handleModeChange}
           />
         </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/components/tutoring/chat-interface.tsx
+++ b/src/components/tutoring/chat-interface.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, useCallback } from 'react';
-import type { Message as PrismaMessage, FiveRPhase, EngagementMode, Session } from '@prisma/client';
+import type { Message as PrismaMessage, FiveRPhase, EngagementMode } from '@prisma/client';
 import { MessageBubble } from './message-bubble';
 import { MessageInput } from './message-input';
 import { StreamingIndicator } from './streaming-indicator';
@@ -17,6 +17,7 @@ interface ChatMessage extends PrismaMessage {
 }
 
 interface ChatInterfaceProps {
+  id?: string;
   sessionId: string;
   initialMessages: ChatMessage[];
   currentPhase: FiveRPhase;
@@ -28,6 +29,7 @@ interface ChatInterfaceProps {
 }
 
 export function ChatInterface({
+  id,
   sessionId,
   initialMessages,
   currentPhase,
@@ -198,9 +200,9 @@ export function ChatInterface({
   };
 
   return (
-    <div className={cn('flex h-full flex-col', className)} role="main" aria-label="Chat interface">
+    <div id={id} className={cn('flex h-full flex-col', className)} role="main" aria-label="Chat interface">
       {/* Messages container */}
-      <div className="flex-1 overflow-y-auto px-4 py-6" role="log" aria-label="Chat messages" aria-live="polite">
+      <div className="flex-1 overflow-y-auto px-4 py-6" role="log" aria-label="Chat messages" aria-live="polite" aria-relevant="additions text">
         {messages.length === 0 ? (
           <div className="flex h-full items-center justify-center text-center">
             <div className="max-w-md space-y-2">

--- a/src/components/tutoring/message-input.tsx
+++ b/src/components/tutoring/message-input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type FormEvent, type KeyboardEvent } from 'react';
+import { useId, useState, type FormEvent, type KeyboardEvent } from 'react';
 import { Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -20,6 +20,7 @@ export function MessageInput({
   className,
 }: MessageInputProps) {
   const [input, setInput] = useState('');
+  const helpTextId = useId();
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -37,7 +38,7 @@ export function MessageInput({
   };
 
   return (
-    <form onSubmit={handleSubmit} className={cn('flex gap-2', className)} aria-label="Send message">
+    <form onSubmit={handleSubmit} className={cn('flex flex-col gap-2 sm:flex-row', className)} aria-label="Send message">
       <Textarea
         value={input}
         onChange={(e) => setInput(e.target.value)}
@@ -47,12 +48,16 @@ export function MessageInput({
         className="min-h-[60px] flex-1 resize-none"
         rows={2}
         aria-label="Message text"
+        aria-describedby={helpTextId}
       />
+      <p id={helpTextId} className="text-xs text-neutral-500">
+        Press Enter to send. Press Shift+Enter for a new line.
+      </p>
       <Button
         type="submit"
         disabled={disabled || !input.trim()}
         size="icon"
-        className="h-[60px] w-[60px]"
+        className="h-[48px] w-full sm:h-[60px] sm:w-[60px]"
         aria-label="Send message"
       >
         <Send className="h-5 w-5" />

--- a/src/components/tutoring/mode-selector.tsx
+++ b/src/components/tutoring/mode-selector.tsx
@@ -62,13 +62,14 @@ export function ModeSelector({ currentMode, onModeChange, disabled, className }:
           disabled={disabled}
           className={cn('gap-2', className)}
           size="sm"
+          aria-label={`Engagement mode: ${currentModeData?.label ?? "Unknown"}`}
         >
           {currentModeData?.icon}
-          <span className="hidden sm:inline">{currentModeData?.label}</span>
+          <span>{currentModeData?.label}</span>
           <ChevronDown className="h-4 w-4 opacity-50" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-64">
+      <DropdownMenuContent align="end" className="w-[min(90vw,16rem)]">
         {MODES.map((mode) => (
           <DropdownMenuItem
             key={mode.key}

--- a/src/components/tutoring/phase-indicator.tsx
+++ b/src/components/tutoring/phase-indicator.tsx
@@ -20,22 +20,23 @@ export function PhaseIndicator({ currentPhase, className }: PhaseIndicatorProps)
   const currentIndex = PHASES.findIndex((p) => p.key === currentPhase);
 
   return (
-    <div className={cn('flex flex-col gap-3', className)}>
-      <div className="flex items-center justify-between gap-2">
+    <div className={cn('flex flex-col gap-3', className)} role="status" aria-live="polite" aria-label="Current learning phase">
+      <div className="grid grid-cols-5 items-center gap-2">
         {PHASES.map((phase, index) => {
           const isActive = phase.key === currentPhase;
           const isPast = index < currentIndex;
 
           return (
-            <div key={phase.key} className="flex flex-1 items-center gap-2">
+            <div key={phase.key} className="flex min-w-0 items-center gap-2">
               <div
                 className={cn(
-                  'flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full border-2 text-xs font-bold transition-all',
+                  'flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border-2 text-xs font-bold transition-all sm:h-10 sm:w-10',
                   isActive && 'border-primary bg-primary text-primary-foreground shadow-md',
                   isPast && 'border-primary/50 bg-primary/10 text-primary',
                   !isActive && !isPast && 'border-neutral-300 bg-neutral-100 text-neutral-400'
                 )}
                 title={`${phase.label}: ${phase.description}`}
+                aria-label={`${phase.label}: ${phase.description}`}
               >
                 {index + 1}
               </div>

--- a/src/components/tutoring/session-header.tsx
+++ b/src/components/tutoring/session-header.tsx
@@ -32,23 +32,23 @@ export function SessionHeader({
   const sessionDuration = formatDistanceToNow(startedAt, { addSuffix: false });
 
   return (
-    <div className={cn('flex items-center justify-between border-b bg-white p-4', className)}>
-      <div className="flex items-center gap-4">
+    <header className={cn('flex flex-col gap-3 border-b bg-white p-4 sm:flex-row sm:items-center sm:justify-between', className)}>
+      <div className="flex items-center gap-3 sm:gap-4">
         <div className="flex items-center gap-2">
           <BookOpen className="h-5 w-5 text-primary" />
           <span className="font-semibold text-neutral-900">{SUBJECT_LABELS[subject]}</span>
         </div>
-        <div className="hidden items-center gap-2 text-sm text-neutral-600 sm:flex">
+        <div className="items-center gap-2 text-sm text-neutral-600 hidden sm:flex" aria-label={`Session duration ${sessionDuration}`}>
           <Clock className="h-4 w-4" />
           <span>{sessionDuration}</span>
         </div>
       </div>
       {onEndSession && (
-        <Button variant="outline" size="sm" onClick={onEndSession} className="gap-2">
+        <Button variant="outline" size="sm" onClick={onEndSession} className="w-full gap-2 sm:w-auto" aria-label="End current learning session">
           <X className="h-4 w-4" />
           <span className="hidden sm:inline">End Session</span>
         </Button>
       )}
-    </div>
+    </header>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve keyboard and screen‑reader navigation in the learning experience to help reach WCAG 2.1 AA goals and support trauma‑informed design (reduce jarring visuals, make focus states clearer). 
- Ensure student-facing learn/chat flows work well on common school devices (Chromebooks and iPads) by improving responsive layout and input affordances.

### Description
- Added a keyboard-accessible skip link and semantic sections for the learn page to allow quick navigation to the conversation area and clarify control regions; updated `src/app/learn/learn-client.tsx` to include the skip link and section landmarks.
- Made the tutoring chat anchorable and improved live-region behavior by exposing an `id` prop on the chat and adding `aria-relevant` on the messages container in `src/components/tutoring/chat-interface.tsx`.
- Improved message input accessibility and mobile UX by adding an instructional helper text exposed via `aria-describedby`, stacking the input and send button on small screens, and making the send button responsive in `src/components/tutoring/message-input.tsx`.
- Polished controls and indicators for assistive tech and small screens by making the mode trigger label visible and adding an explicit `aria-label` and viewport-constrained dropdown width in `src/components/tutoring/mode-selector.tsx`, and adding `role="status"`, `aria-live`, and explicit `aria-label`s for phase steps and compact sizing tweaks in `src/components/tutoring/phase-indicator.tsx`.
- Improved session header semantics and responsiveness by using a `header` element, exposing session-duration labeling, and making the end-session button behave/accessibly on small screens in `src/components/tutoring/session-header.tsx`.
- Softened intense background accents and strengthened keyboard focus outlines in `src/app/globals.css` to reduce visual stressors and improve focus visibility for keyboard users.

### Testing
- Ran `npm run lint` which failed in this environment due to the `next` binary not being available (`sh: 1: next: not found`).
- Ran `npm run build` which also failed for the same missing `next` binary error in the environment.
- Attempted an automated browser capture targeting `http://127.0.0.1:3000/learn` via Playwright but the local app server was not reachable and the navigation returned `ERR_EMPTY_RESPONSE`.
- Files changed and static code edits were committed locally; runtime checks requiring a full Next.js install or running server should be executed in CI or a developer environment to validate rendering and a11y behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989b3ca6844832a8ad9f511cfee7496)