### PR TITLE
Fix Next.js route handler context typing for tenant admin POST handlers

### DIFF
--- a/src/app/api/admin/super/tenants/[tenantId]/interventions/route.ts
+++ b/src/app/api/admin/super/tenants/[tenantId]/interventions/route.ts
@@ -8,8 +8,9 @@ const requestSchema = z.object({
   details: z.string().max(5000).optional(),
 });
 
-export async function POST(request: Request, { params }: { params: { tenantId: string } }) {
+export async function POST(request: Request, context: { params: Promise<{ tenantId: string }> }) {
   try {
+    const params = await context.params;
     const actor = await requireRole(['PLATFORM_ADMIN']);
     const body = requestSchema.parse(await request.json());
 

--- a/src/app/api/admin/super/tenants/[tenantId]/invoice/route.ts
+++ b/src/app/api/admin/super/tenants/[tenantId]/invoice/route.ts
@@ -14,8 +14,9 @@ const requestSchema = z.object({
   ).min(1),
 });
 
-export async function POST(request: Request, { params }: { params: { tenantId: string } }) {
+export async function POST(request: Request, context: { params: Promise<{ tenantId: string }> }) {
   try {
+    const params = await context.params;
     const actor = await requireRole(['PLATFORM_ADMIN']);
     const body = requestSchema.parse(await request.json());
 


### PR DESCRIPTION
### Motivation
- Vercel/Next.js build failed with a type error indicating the `POST` route handlers' second argument shape was invalid for dynamic tenant routes, so handlers needed to match Next.js 15 context typing. 

### Description
- Updated `POST` handler signatures in `src/app/api/admin/super/tenants/[tenantId]/interventions/route.ts` and `src/app/api/admin/super/tenants/[tenantId]/invoice/route.ts` to use `context: { params: Promise<{ tenantId: string }> }`.
- Await `context.params` inside each handler and use `params.tenantId` when invoking `createManualIntervention` and `issueDistrictInvoice` respectively.
- Applied the same fix to both endpoints to prevent the same build-time type error for dynamic route params.

### Testing
- Reproduced the original build error context from the Vercel log which motivated the change (type error on `POST` export) and confirmed the handler signature was the cause.
- Attempted `npm run build` locally but it failed because the `next` binary was not present in this environment, so a full local build could not be completed. 
- Attempted installing dependencies with `npm ci --no-audit --no-fund` but the install appeared to hang and was terminated, so automated build verification was not completed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989b968c700832ab25853a47ca5e227)