### PR TITLE
Add grade band overview and navigation README files

### DIFF
--- a/05-grade-bands/3-5/README.md
+++ b/05-grade-bands/3-5/README.md
@@ -1,0 +1,45 @@
+---
+title: "3-5 Grade Band - FG2G Curriculum"
+section: "Grade Bands"
+subsection: "3-5"
+source_path: "05-grade-bands/3-5/README.md"
+document_type: "curriculum"
+---
+# 3-5 Grade Band (Ages 8-11)
+
+## Overview
+
+The 3-5 grade band marks a developmental transition from adult-directed to student-selected approaches within the 5Rs Framework. Students ages 8-11 are developing metacognitive awareness and can begin to identify their own emotional and physiological states with increasing accuracy. The curriculum honors this growth by offering structured choice in how students check in, regulate, reflect, and share their learning -- while maintaining the predictable framework that trauma-informed practice requires.
+
+**Key Developmental Features:**
+- Student-selected check-in formats (verbal, written, drawing)
+- Regulation scale (1-5) with garden imagery
+- Growth journaling with self-assessment calibration
+- Multi-step problem-solving and cross-curricular garden projects
+- Introduction of reasoning moves (CONNECT, COMPARE, QUESTION, DECOMPOSE)
+
+## Contents
+
+| Part | Phase | Title | Core Question | Duration |
+|------|-------|-------|---------------|----------|
+| [Part 1](part-1.md) | **Root** | Student-Selected Grounding | "Am I safe and ready to learn?" | 5-7 min |
+| [Part 2](part-2.md) | **Regulate** | Building Self-Regulation | "Can I return to my window of tolerance?" | 5-8 min |
+| [Part 3](part-3.md) | **Reflect** | Structured Inquiry and Journaling | "What am I thinking, and why?" | 10-15 min |
+| [Part 4](part-4.md) | **Restore** | Error Analysis and Growth | "What can I learn from this mistake?" | 10-15 min |
+| [Part 5](part-5.md) | **Reconnect** | Community Connections | "How does this connect to my world?" | 10-15 min |
+
+## Educator Quick Reference
+
+- **Entry Ritual**: Garden gathering with student-selected check-in format
+- **Check-In Tool**: Regulation scale 1-5 with garden imagery (seed to full bloom)
+- **Regulation Support**: Structured choice menu, garden-based grounding activities (soil check-in, seed sorting, watering ritual)
+- **Reflection Tools**: Growth journals, graphic organizers, partner reflection with sentence stems
+- **Error Language**: Structured mistake analysis with growth mindset language
+- **Family Connection**: Garden projects, recipe cards with harvest, family involvement in community sharing
+
+## Navigation
+
+- [Back to Grade Bands Overview](../README.md)
+- [Previous Grade Band: K-2](../K-2/)
+- [Next Grade Band: 6-8](../6-8/)
+- [5Rs Framework Reference](../../04-5rs-framework/overview.md)

--- a/05-grade-bands/6-8/README.md
+++ b/05-grade-bands/6-8/README.md
@@ -1,0 +1,46 @@
+---
+title: "6-8 Grade Band - FG2G Curriculum"
+section: "Grade Bands"
+subsection: "6-8"
+source_path: "05-grade-bands/6-8/README.md"
+document_type: "curriculum"
+---
+# 6-8 Grade Band (Ages 11-14)
+
+## Overview
+
+The 6-8 grade band adapts the 5Rs Framework for middle school students navigating the social-emotional turbulence of early adolescence. Students ages 11-14 are capable of sophisticated self-assessment and benefit from peer grounding partnerships. The curriculum transitions from adult-led check-ins to student-owned regulation awareness, building the metacognitive foundation that middle schoolers need to manage academic challenges alongside identity development, social pressure, and hormonal changes.
+
+**Key Developmental Features:**
+- Numeric self-regulation scale (0-100)
+- Peer grounding partnerships and collaborative regulation
+- Independent grounding strategy menu (6+ strategies)
+- Hypothesis testing, experimental design, and data analysis in the garden
+- Community application projects and food justice awareness
+- Mentoring younger students as a reconnection pathway
+
+## Contents
+
+| Part | Phase | Title | Core Question | Duration |
+|------|-------|-------|---------------|----------|
+| [Part 1](part-1.md) | **Root** | Self-Assessment and Peer Grounding | "Am I safe and ready to learn?" | 3-5 min |
+| [Part 2](part-2.md) | **Regulate** | Independent Regulation Strategies | "Can I return to my window of tolerance?" | 3-5 min |
+| [Part 3](part-3.md) | **Reflect** | Collaborative Inquiry and Analysis | "What am I thinking, and why?" | 15-20 min |
+| [Part 4](part-4.md) | **Restore** | Structured Error Analysis | "What can I learn from this mistake?" | 15-20 min |
+| [Part 5](part-5.md) | **Reconnect** | Community Application Projects | "How does this connect to my world?" | 5-10 min |
+
+## Educator Quick Reference
+
+- **Entry Ritual**: Self-directed grounding with numeric self-rating and peer partnerships
+- **Check-In Tool**: 0-100 regulation scale with self-assessment accuracy tracking
+- **Regulation Support**: Independent strategy menu, peer co-regulation, garden observation journaling
+- **Reflection Tools**: Analytical journals, evidence-based discussion, collaborative inquiry protocols
+- **Error Approach**: Structured error analysis protocols with hypothesis testing
+- **Community Connection**: Service learning, food justice projects, cross-age mentoring
+
+## Navigation
+
+- [Back to Grade Bands Overview](../README.md)
+- [Previous Grade Band: 3-5](../3-5/)
+- [Next Grade Band: 9-12](../9-12/)
+- [5Rs Framework Reference](../../04-5rs-framework/overview.md)

--- a/05-grade-bands/9-12/README.md
+++ b/05-grade-bands/9-12/README.md
@@ -1,0 +1,46 @@
+---
+title: "9-12 Grade Band - FG2G Curriculum"
+section: "Grade Bands"
+subsection: "9-12"
+source_path: "05-grade-bands/9-12/README.md"
+document_type: "curriculum"
+---
+# 9-12 Grade Band (Ages 14-18)
+
+## Overview
+
+The 9-12 grade band represents the culmination of the 5Rs developmental trajectory. High school students have internalized grounding practices across years of instruction and now direct their own regulation with minimal adult scaffolding. The educator's role shifts from facilitator to consultant. Students take on mentorship roles, guiding younger students through the 5Rs while applying their own learning to authentic garden-to-community enterprise projects that create meaningful change.
+
+**Key Developmental Features:**
+- Self-directed Personal Grounding Plans (PGP)
+- Autonomous regulation with personalized strategy portfolios
+- Metacognitive analysis and self-directed inquiry across disciplines
+- Complex research, enterprise planning, and community problem-solving
+- Mentorship of younger students across all 5Rs phases
+- Garden stewardship leadership roles (Garden Manager, Soil Scientist, Irrigation Engineer, Harvest Coordinator)
+- Capstone portfolios with reflective synthesis
+
+## Contents
+
+| Part | Phase | Title | Core Question | Duration |
+|------|-------|-------|---------------|----------|
+| [Part 1](part-1.md) | **Root** | Self-Directed Grounding | "Am I safe and ready to learn?" | 2-5 min |
+| [Part 2](part-2.md) | **Regulate** | Autonomous Self-Regulation | "Can I return to my window of tolerance?" | 2-5 min |
+| [Part 3](part-3.md) | **Reflect** | Self-Directed Inquiry and Metacognition | "What am I thinking, and why?" | 15-25 min |
+| [Part 4](part-4.md) | **Restore** | Independent Error Analysis and Revision | "What can I learn from this mistake?" | 15-25 min |
+| [Part 5](part-5.md) | **Reconnect** | Real-World Enterprise and Leadership | "How does this connect to my world?" | Variable |
+
+## Educator Quick Reference
+
+- **Entry Ritual**: Student-paced, self-directed from Personal Grounding Plan
+- **Check-In Tool**: Self-rating 0-100 scale with accurate interoceptive awareness
+- **Regulation Support**: Personalized regulation portfolio, peer and self-directed strategies
+- **Reflection Tools**: Self-directed inquiry, research-based reflection, metacognitive analysis journals
+- **Error Approach**: Independent error analysis, peer review, revision cycles, TRACE protocol mastery
+- **Community Connection**: Garden-to-community enterprise projects, environmental advocacy, sustainable business ventures, capstone presentations
+
+## Navigation
+
+- [Back to Grade Bands Overview](../README.md)
+- [Previous Grade Band: 6-8](../6-8/)
+- [5Rs Framework Reference](../../04-5rs-framework/overview.md)

--- a/05-grade-bands/K-2/README.md
+++ b/05-grade-bands/K-2/README.md
@@ -1,0 +1,44 @@
+---
+title: "K-2 Grade Band - FG2G Curriculum"
+section: "Grade Bands"
+subsection: "K-2"
+source_path: "05-grade-bands/K-2/README.md"
+document_type: "curriculum"
+---
+# K-2 Grade Band (Ages 5-8)
+
+## Overview
+
+The K-2 grade band adapts the 5Rs Framework for the youngest learners, ages 5-8. At this developmental stage, children depend heavily on adults for co-regulation, communicate emotion primarily through behavior and body language, and learn best through concrete, multisensory experiences. The garden serves as a living classroom where predictable rituals, picture-based tools, and hands-on activities create the felt safety that trauma-informed learning requires.
+
+**Key Developmental Features:**
+- Adult-directed grounding and co-regulation
+- Picture card and weather-based emotion identification
+- Sensory-rich garden rituals (songs, soil, herbs, movement)
+- Concrete, joyful error reframing ("Oops and Grow")
+- Family engagement through take-home seeds, recipes, and "Ask Me About..." cards
+
+## Contents
+
+| Part | Phase | Title | Core Question | Duration |
+|------|-------|-------|---------------|----------|
+| [Part 1](part-1.md) | **Root** | Grounding and Safety | "Am I safe and ready to learn?" | 5-8 min |
+| [Part 2](part-2.md) | **Regulate** | Co-Regulation and Calming | "Can I return to my window of tolerance?" | 5-10 min |
+| [Part 3](part-3.md) | **Reflect** | Observing and Wondering | "What am I thinking, and why?" | 10-15 min |
+| [Part 4](part-4.md) | **Restore** | Learning from Mistakes | "What can I learn from this mistake?" | 10-15 min |
+| [Part 5](part-5.md) | **Reconnect** | Sharing and Celebrating Growth | "How does this connect to my world?" | 5-10 min |
+
+## Educator Quick Reference
+
+- **Entry Ritual**: Garden gate gathering, transition song, grounding touch, picture card check-in, ready signal
+- **Check-In Tool**: Weather picture cards (sunshine, partly cloudy, rainy, storm, fog)
+- **Regulation Support**: Breathing buddies, movement songs, sensory stations, watering rituals
+- **Error Language**: "Oops and Grow" -- mistakes celebrated as brain-growing moments
+- **Closing Ritual**: Journal drawing, partner share, growth cheer, closing song
+- **Family Connection**: Weekly take-home activities, harvest sharing, family garden events
+
+## Navigation
+
+- [Back to Grade Bands Overview](../README.md)
+- [Next Grade Band: 3-5](../3-5/)
+- [5Rs Framework Reference](../../04-5rs-framework/overview.md)

--- a/05-grade-bands/README.md
+++ b/05-grade-bands/README.md
@@ -1,0 +1,105 @@
+---
+title: "Grade Bands - FG2G Curriculum"
+section: "Grade Bands"
+source_path: "05-grade-bands/README.md"
+document_type: "curriculum"
+---
+# Grade Bands - FG2G Curriculum
+
+## Section Overview
+
+This section contains the developmentally adapted implementations of the 5Rs Framework (Root, Regulate, Reflect, Restore, Reconnect) for four grade bands spanning kindergarten through twelfth grade. Each grade band translates the same core framework into age-appropriate language, activities, assessments, and educator guidance -- ensuring that trauma-informed, garden-based instruction meets students where they are developmentally.
+
+The grade bands are the heart of the FG2G curriculum. While the [5Rs Framework](../04-5rs-framework/overview.md) defines *what* happens at each phase, the grade bands define *how* it happens for each age group.
+
+## Contents
+
+| Grade Band | Ages | Description | Directory |
+|-----------|------|-------------|-----------|
+| [K-2](K-2/) | 5-8 | Adult-directed grounding, picture card check-ins, sensory rituals, concrete garden activities | `K-2/` |
+| [3-5](3-5/) | 8-11 | Student-selected check-ins, regulation scales, growth journaling, cross-curricular garden projects | `3-5/` |
+| [6-8](6-8/) | 11-14 | Self-assessment and peer grounding, numeric regulation scales, independent strategy menus, community application | `6-8/` |
+| [9-12](9-12/) | 14-18 | Self-directed grounding, personal grounding plans, mentorship roles, garden-to-community enterprise | `9-12/` |
+
+## Structure Within Each Grade Band
+
+Each grade band contains five parts aligned with the 5Rs phases:
+
+| Part | Phase | Core Question |
+|------|-------|---------------|
+| Part 1 | **Root** | "Am I safe and ready to learn?" |
+| Part 2 | **Regulate** | "Can I return to my window of tolerance?" |
+| Part 3 | **Reflect** | "What am I thinking, and why?" |
+| Part 4 | **Restore** | "What can I learn from this mistake?" |
+| Part 5 | **Reconnect** | "How does this connect to my world?" |
+
+## Developmental Progression Across Grade Bands
+
+The 5Rs Framework is consistent across all four grade bands, but the *how* shifts as students develop greater autonomy, self-awareness, and cognitive capacity.
+
+### Root Phase Progression
+
+| Grade Band | Check-In Method | Grounding Approach | Educator Role |
+|-----------|----------------|-------------------|---------------|
+| K-2 | Picture cards (weather imagery) | Adult-led sensory rituals, songs, physical grounding | Warm director -- leads all routines |
+| 3-5 | Student-selected format (verbal, written, drawing) | Choice from structured menu, garden-based grounding | Supportive guide -- offers choices within structure |
+| 6-8 | Numeric self-rating (0-100 scale) | Independent strategy menu, peer grounding partnerships | Collaborative coach -- monitors and consults |
+| 9-12 | Self-directed Personal Grounding Plan | Fully autonomous, personalized strategy selection | Available consultant -- trusts student self-knowledge |
+
+### Regulate Phase Progression
+
+| Grade Band | Regulation Tool | Co-Regulation Model | Garden Connection |
+|-----------|----------------|--------------------|--------------------|
+| K-2 | Breathing buddies, movement songs | Adult provides primary co-regulation | Watering rhythm, seed sorting, raking patterns |
+| 3-5 | Regulation scale (1-5 with garden imagery) | Adult guides, student begins self-monitoring | Soil preparation, planting sequences, garden journals |
+| 6-8 | Self-regulation toolkit, peer partnerships | Peers provide co-regulation with adult oversight | Independent garden tasks, observation journaling |
+| 9-12 | Personalized regulation portfolio | Self-regulation with mentorship of younger students | Garden stewardship roles, leadership responsibilities |
+
+### Reflect Phase Progression
+
+| Grade Band | Reflection Method | TRACE Protocol | Reasoning Moves |
+|-----------|------------------|----------------|-----------------|
+| K-2 | Drawing, oral sharing, simple sentence starters | Educator-modeled think-alouds | Observing, Comparing |
+| 3-5 | Structured journals, partner reflection, graphic organizers | Guided practice with scaffolded steps | Sequencing, Classifying, beginning Inferring |
+| 6-8 | Analytical journals, collaborative inquiry, evidence-based discussion | Independent use with peer feedback | Inferring, Predicting, beginning Evaluating |
+| 9-12 | Self-directed inquiry, research-based reflection, metacognitive analysis | Autonomous application across disciplines | Full range including Evaluating and systems thinking |
+
+### Restore Phase Progression
+
+| Grade Band | Error Response | Academic Integration | Growth Documentation |
+|-----------|---------------|---------------------|---------------------|
+| K-2 | "Oops and Grow" -- normalized, concrete, joyful | Garden-based counting, sorting, life cycles | Spark stickers, simple portfolio entries |
+| 3-5 | Mistake analysis with growth language | Multi-step problem-solving, cross-curricular projects | Growth journals with self-assessment calibration |
+| 6-8 | Structured error analysis protocols | Hypothesis testing, experimental design, data analysis | Portfolio with evidence of growth over time |
+| 9-12 | Independent error analysis, peer review, revision cycles | Complex research, enterprise planning, community problem-solving | Capstone portfolio with reflective synthesis |
+
+### Reconnect Phase Progression
+
+| Grade Band | Sharing Method | Community Connection | Family Engagement |
+|-----------|---------------|---------------------|-------------------|
+| K-2 | Show-and-tell, partner sharing, garden walks | Harvest sharing, family planting days | Take-home seeds, "Ask Me About..." cards |
+| 3-5 | Cross-curricular presentations, garden exhibitions | Community garden contributions, neighborhood sharing | Family garden projects, recipe cards with harvest |
+| 6-8 | Community application projects, food justice awareness | Service learning, mentoring younger students, enterprise skills | Family involvement in community projects |
+| 9-12 | Enterprise projects, public presentations, capstone portfolios | Garden-to-community enterprise, environmental advocacy, sustainable business | Family as stakeholders in community enterprise |
+
+## Quick Start for Educators
+
+1. **Identify your grade band** from the table above.
+2. **Read Part 1 (Root)** for your grade band to understand how to open each session.
+3. **Read parts sequentially** (1 through 5) to understand the full 5Rs cycle for your students.
+4. **Reference the [5Rs Framework Overview](../04-5rs-framework/overview.md)** for the theoretical foundation underlying all grade bands.
+5. **Consult [Instructional Strategies](../06-instructional-strategies/README.md)** for cross-grade-band teaching techniques.
+
+## Cross-Grade-Band Considerations
+
+### Multi-Grade Classrooms
+
+When teaching across grade bands (e.g., a combined 2nd/3rd grade class), use the lower grade band's Root and Regulate phases for consistency and felt safety, then differentiate during Reflect, Restore, and Reconnect phases based on individual student readiness.
+
+### Vertical Articulation
+
+Students transitioning between grade bands (e.g., 5th to 6th grade) should experience a gradual shift in expectations rather than an abrupt change. The final quarter of each grade band can introduce elements from the next band's approach to ease transitions.
+
+### Students New to the 5Rs
+
+Students entering at upper grade bands without prior 5Rs experience may need temporary scaffolding from a lower grade band's Root and Regulate protocols while they build regulation capacity. Meet the student where they are, not where the grade band assumes they should be.


### PR DESCRIPTION
Complete the 05-grade-bands section by adding a main README with developmental progression tables, cross-grade-band comparison, and educator quick-start guidance, plus individual README files for each grade band subdirectory (K-2, 3-5, 6-8, 9-12) with phase navigation and educator quick-reference summaries.

https://claude.ai/code/session_01Ef8caw1hvRMcBZ4sbp4mh3