### PR TITLE
Fix useChat callback dependency warnings for updatePhaseInternal

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -187,7 +187,7 @@ export function useChat(): UseChatReturn {
     }
   }, [setLoading, startSession, setEngagementMode]);
 
-  async function updatePhaseInternal(sid: string, phase: string) {
+  const updatePhaseInternal = useCallback(async (sid: string, phase: string) => {
     setPhase(phase as Parameters<typeof setPhase>[0]);
     try {
       await fetch(`/api/sessions/${sid}`, {
@@ -198,12 +198,12 @@ export function useChat(): UseChatReturn {
     } catch {
       // Silently fail phase persistence -- local state is updated
     }
-  }
+  }, [setPhase]);
 
   const updatePhase = useCallback(async (phase: string) => {
     if (!sessionId) return;
     await updatePhaseInternal(sessionId, phase);
-  }, [sessionId, setPhase]);
+  }, [sessionId, updatePhaseInternal]);
 
   const updateEngagementMode = useCallback(async (mode: string) => {
     if (!sessionId) return;


### PR DESCRIPTION
### Motivation
- Resolve `react-hooks/exhaustive-deps` warnings by giving `updatePhaseInternal` a stable identity so other callbacks can safely reference it.

### Description
- Convert `updatePhaseInternal` to a memoized `useCallback` with `[setPhase]` as its dependency.
- Update `updatePhase` to list `updatePhaseInternal` in its dependency array instead of `setPhase`.

### Testing
- Ran `npm ci` in the workspace to install dependencies but the install did not complete in this environment (hung/failed).
- Ran `npm run lint -- src/hooks/useChat.ts` which failed because the `next` binary was not available before dependencies were installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989bc5da800832a8ba4781e2e5df0af)