### PR TITLE
Suppress Prisma/OpenTelemetry webpack warning during Next builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,17 @@ const nextConfig = {
       bodySizeLimit: "2mb",
     },
   },
+  webpack: (config) => {
+    config.ignoreWarnings = [
+      ...(config.ignoreWarnings ?? []),
+      {
+        module: /@opentelemetry\/instrumentation\/build\/esm\/platform\/node\/instrumentation\.js/,
+        message: /Critical dependency: the request of a dependency is an expression/,
+      },
+    ];
+
+    return config;
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
### Motivation
- Reduce noisy build output caused by a known Prisma -> @opentelemetry instrumentation warning during Next.js builds by filtering the specific webpack warning rather than changing dependencies or runtime code.

### Description
- Add a `webpack` hook in `next.config.js` that appends an entry to `config.ignoreWarnings` to match the module `@opentelemetry/instrumentation/.../platform/node/instrumentation.js` and the message `Critical dependency: the request of a dependency is an expression`.

### Testing
- Attempted `npm ci --no-audit --no-fund` followed by `npm run build`, but dependency installation stalled and `next build` failed with `sh: 1: next: not found`, so no successful automated build verification was possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989bdc437dc832a917792bb1e8507f3)