### PR TITLE
Add graph-based prerequisite recommendations for failed assessments

### DIFF
--- a/src/app/api/assessments/[id]/submit/route.ts
+++ b/src/app/api/assessments/[id]/submit/route.ts
@@ -3,6 +3,7 @@ import { auth } from '@clerk/nextjs/server';
 import { db } from '@/lib/db';
 import { generateAIFeedback } from '@/lib/assessments/ai-feedback-generator';
 import { updateProgress } from '@/lib/assessments/progress-calculator';
+import { suggestPrerequisiteTopics } from '@/lib/curriculum/prerequisite-graph';
 import { z } from 'zod';
 
 const submitAssessmentSchema = z.object({
@@ -57,7 +58,20 @@ export async function POST(
             },
           },
         },
-        standard: true,
+        standard: {
+          include: {
+            topics: {
+              include: {
+                prerequisites: {
+                  select: {
+                    id: true,
+                    name: true,
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     });
 
@@ -92,6 +106,18 @@ export async function POST(
       includeScaffold: true,
     });
 
+    const prerequisiteRecommendations = feedback.isCorrect
+      ? []
+      : suggestPrerequisiteTopics(
+        assessment.standard?.topics.map((topic) => ({
+          id: topic.id,
+          name: topic.name,
+          prerequisites: topic.prerequisites,
+        })) ?? [],
+        assessment.standard?.topics[0]?.name ?? assessment.question,
+        3,
+      );
+
     // Update assessment with response and feedback
     const updatedAssessment = await db.assessment.update({
       where: { id: assessmentId },
@@ -105,6 +131,7 @@ export async function POST(
           scaffoldHints: feedback.scaffoldHints,
           commonErrors: feedback.commonErrors,
           nextSteps: feedback.nextSteps,
+          prerequisiteRecommendations,
           timeTaken,
         },
       },
@@ -131,6 +158,7 @@ export async function POST(
           feedback: feedback.feedback,
           scaffoldHints: feedback.scaffoldHints,
           nextSteps: feedback.nextSteps,
+          prerequisiteRecommendations,
         },
       },
       message: 'Assessment submitted successfully',

--- a/src/lib/curriculum/prerequisite-graph.test.ts
+++ b/src/lib/curriculum/prerequisite-graph.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { suggestPrerequisiteTopics, type TopicDependencyNode } from '@/lib/curriculum/prerequisite-graph';
+
+const topicGraph: TopicDependencyNode[] = [
+  {
+    id: 'algebraic-operations',
+    name: 'Algebraic Operations',
+    prerequisites: [],
+  },
+  {
+    id: 'factoring',
+    name: 'Factoring',
+    prerequisites: [{ id: 'algebraic-operations', name: 'Algebraic Operations' }],
+  },
+  {
+    id: 'quadratic-equations',
+    name: 'Quadratic Equations',
+    prerequisites: [{ id: 'factoring', name: 'Factoring' }],
+  },
+];
+
+describe('prerequisite graph recommendations', () => {
+  it('returns direct and upstream dependencies for a failed topic', () => {
+    const recommendations = suggestPrerequisiteTopics(topicGraph, 'Quadratic Equations', 3);
+
+    expect(recommendations).toEqual([
+      {
+        topicName: 'Factoring',
+        reason: 'direct_prerequisite',
+        distance: 1,
+      },
+      {
+        topicName: 'Algebraic Operations',
+        reason: 'upstream_prerequisite',
+        distance: 2,
+      },
+    ]);
+  });
+
+  it('uses domain override when graph data is unavailable', () => {
+    const recommendations = suggestPrerequisiteTopics([], 'Quadratic Equations', 3);
+
+    expect(recommendations.map((entry) => entry.topicName)).toEqual([
+      'Factoring',
+      'Algebraic Operations',
+    ]);
+    expect(recommendations.every((entry) => entry.reason === 'domain_override')).toBe(true);
+  });
+});

--- a/src/lib/curriculum/prerequisite-graph.ts
+++ b/src/lib/curriculum/prerequisite-graph.ts
@@ -1,0 +1,110 @@
+export interface TopicDependencyNode {
+  id: string;
+  name: string;
+  prerequisites: Array<{
+    id: string;
+    name: string;
+  }>;
+}
+
+export interface PrerequisiteSuggestion {
+  topicName: string;
+  reason: 'direct_prerequisite' | 'upstream_prerequisite' | 'domain_override';
+  distance: number;
+}
+
+const DOMAIN_DEPENDENCY_OVERRIDES: Record<string, string[]> = {
+  'quadratic equations': ['Factoring', 'Algebraic Operations'],
+};
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function toNodeMap(topics: TopicDependencyNode[]): Map<string, TopicDependencyNode> {
+  return new Map(topics.map((topic) => [topic.id, topic]));
+}
+
+function findStartingTopic(topics: TopicDependencyNode[], failedTopicOrConcept: string): TopicDependencyNode | null {
+  const normalizedTarget = normalize(failedTopicOrConcept);
+
+  const exactMatch = topics.find((topic) => normalize(topic.name) === normalizedTarget);
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const partialMatch = topics.find((topic) => {
+    const normalizedName = normalize(topic.name);
+    return normalizedName.includes(normalizedTarget) || normalizedTarget.includes(normalizedName);
+  });
+
+  return partialMatch ?? null;
+}
+
+export function suggestPrerequisiteTopics(
+  topics: TopicDependencyNode[],
+  failedTopicOrConcept: string,
+  maxSuggestions = 3,
+): PrerequisiteSuggestion[] {
+  if (!failedTopicOrConcept.trim()) {
+    return [];
+  }
+
+  const startingTopic = findStartingTopic(topics, failedTopicOrConcept);
+
+  if (!startingTopic) {
+    const domainOverrides = DOMAIN_DEPENDENCY_OVERRIDES[normalize(failedTopicOrConcept)] ?? [];
+    return domainOverrides.slice(0, maxSuggestions).map((topicName) => ({
+      topicName,
+      reason: 'domain_override',
+      distance: 1,
+    }));
+  }
+
+  const byId = toNodeMap(topics);
+  const suggestions: PrerequisiteSuggestion[] = [];
+  const visited = new Set<string>();
+  const queue: Array<{ topicId: string; distance: number }> = [{ topicId: startingTopic.id, distance: 0 }];
+
+  while (queue.length > 0 && suggestions.length < maxSuggestions) {
+    const current = queue.shift();
+    if (!current || visited.has(current.topicId)) {
+      continue;
+    }
+
+    visited.add(current.topicId);
+    const topic = byId.get(current.topicId);
+    if (!topic) {
+      continue;
+    }
+
+    for (const prerequisite of topic.prerequisites) {
+      if (visited.has(prerequisite.id)) {
+        continue;
+      }
+
+      suggestions.push({
+        topicName: prerequisite.name,
+        reason: current.distance === 0 ? 'direct_prerequisite' : 'upstream_prerequisite',
+        distance: current.distance + 1,
+      });
+
+      queue.push({ topicId: prerequisite.id, distance: current.distance + 1 });
+
+      if (suggestions.length >= maxSuggestions) {
+        break;
+      }
+    }
+  }
+
+  if (suggestions.length > 0) {
+    return suggestions;
+  }
+
+  const domainOverrides = DOMAIN_DEPENDENCY_OVERRIDES[normalize(failedTopicOrConcept)] ?? [];
+  return domainOverrides.slice(0, maxSuggestions).map((topicName) => ({
+    topicName,
+    reason: 'domain_override',
+    distance: 1,
+  }));
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic, graph-structured prerequisite recommendations when a student fails an assessment because vector similarity alone is insufficient for logical dependency tracing.

### Description
- Add a graph-first utility `suggestPrerequisiteTopics` (`src/lib/curriculum/prerequisite-graph.ts`) that traverses `Topic.prerequisites` with BFS to return direct and upstream prerequisite suggestions and supports domain-level fallback overrides (e.g., "Quadratic Equations" → ["Factoring", "Algebraic Operations"]).
- Integrate prerequisite suggestion generation into the assessment submission flow by returning and persisting `prerequisiteRecommendations` for failed responses in the `POST /api/assessments/[id]/submit` handler (`src/app/api/assessments/[id]/submit/route.ts`) and by including the topics + prerequisites in the DB query.
- Add unit tests (`src/lib/curriculum/prerequisite-graph.test.ts`) that validate direct/upstream traversal and fallback behavior when graph data is missing.

### Testing
- Added unit tests for the new graph logic via `src/lib/curriculum/prerequisite-graph.test.ts` and a parser test was also present; these tests are included in the repo but not executed successfully in the local environment.
- Attempted to run `npm test -- src/lib/curriculum/prerequisite-graph.test.ts src/lib/curriculum/parser.test.ts` which failed because the `vitest` binary was not available locally.
- Attempted `npx vitest run src/lib/curriculum/prerequisite-graph.test.ts src/lib/curriculum/parser.test.ts` which failed due to npm registry access errors (`403 Forbidden`), preventing test execution in this environment.
- The tests should run in CI (or locally) once dev dependencies are installed and network/registry access is available; behavior is covered by the added unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c2b0f620832aacdf06826a56ea30)