### PR TITLE
Exclude server-only dependencies from client bundle

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,7 +12,7 @@ const nextConfig = {
       bodySizeLimit: "2mb",
     },
   },
-  webpack: (config) => {
+  webpack: (config, { isServer }) => {
     config.ignoreWarnings = [
       ...(config.ignoreWarnings ?? []),
       {
@@ -20,6 +20,18 @@ const nextConfig = {
         message: /Critical dependency: the request of a dependency is an expression/,
       },
     ];
+
+    // Exclude server-only dependencies from client bundle
+    if (!isServer) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        // Make server-only modules resolve to empty object on client
+        'dd-trace': false,
+        '@datadog/libdatadog': false,
+        '@datadog/openfeature-node-server': false,
+        '@openfeature/server-sdk': false,
+      };
+    }
 
     return config;
   },

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -5,6 +5,12 @@
  * monitoring providers (Datadog APM, Sentry) before request handling.
  */
 export async function register() {
+  // Only run on server-side (instrumentation hooks should only run server-side,
+  // but this is an extra safety check)
+  if (typeof window !== 'undefined') {
+    return;
+  }
+
   // Datadog APM — must initialise before other imports
   if (process.env.DD_API_KEY) {
     const { initDatadog } = await import('@/lib/datadog');


### PR DESCRIPTION
## Summary
Prevent server-only monitoring and feature flag dependencies from being bundled into the client-side JavaScript, reducing bundle size and avoiding runtime errors in the browser.

## Changes
- **next.config.js**: Updated webpack configuration to accept the `isServer` parameter and conditionally alias server-only packages (`dd-trace`, `@datadog/libdatadog`, `@datadog/openfeature-node-server`, `@openfeature/server-sdk`) to `false` when building for the client bundle
- **src/instrumentation.ts**: Added a safety check to ensure the `register()` function only executes on the server-side by returning early if `window` is defined (client-side environment)

## Implementation Details
- The webpack alias configuration resolves server-only modules to `false` on the client, preventing them from being included in the client bundle
- The instrumentation safety check provides defense-in-depth, ensuring that even if the instrumentation hook somehow runs on the client, it will exit gracefully
- These changes maintain compatibility with Next.js instrumentation hooks while ensuring proper environment separation

https://claude.ai/code/session_01N7pvSTpx8qzUnj5EsJGxxk