### PR TITLE
Complete grade band content with standardized metadata and transition…

### DIFF
--- a/01-front-matter/acknowledgments.md
+++ b/01-front-matter/acknowledgments.md
@@ -3,6 +3,7 @@ title: "Acknowledgments"
 section: "Front Matter"
 source_path: "01-front-matter/acknowledgments.md"
 document_type: "curriculum"
+subsection: "acknowledgments"
 ---
 # Acknowledgments
 

--- a/01-front-matter/copyright.md
+++ b/01-front-matter/copyright.md
@@ -3,6 +3,7 @@ title: "Copyright"
 section: "Front Matter"
 source_path: "01-front-matter/copyright.md"
 document_type: "curriculum"
+subsection: "copyright"
 ---
 # Copyright
 

--- a/01-front-matter/dedication.md
+++ b/01-front-matter/dedication.md
@@ -3,6 +3,7 @@ title: "Dedication"
 section: "Front Matter"
 source_path: "01-front-matter/dedication.md"
 document_type: "curriculum"
+subsection: "dedication"
 ---
 # Dedication
 

--- a/01-front-matter/foreword.md
+++ b/01-front-matter/foreword.md
@@ -3,6 +3,7 @@ title: "Foreword"
 section: "Front Matter"
 source_path: "01-front-matter/foreword.md"
 document_type: "curriculum"
+subsection: "foreword"
 ---
 # Foreword
 

--- a/01-front-matter/how-to-use-this-guide.md
+++ b/01-front-matter/how-to-use-this-guide.md
@@ -3,6 +3,7 @@ title: "How to Use This Guide"
 section: "Front Matter"
 source_path: "01-front-matter/how-to-use-this-guide.md"
 document_type: "curriculum"
+subsection: "how-to-use"
 ---
 # How to Use This Guide
 

--- a/01-front-matter/title-page.md
+++ b/01-front-matter/title-page.md
@@ -3,6 +3,7 @@ title: "Title Page"
 section: "Front Matter"
 source_path: "01-front-matter/title-page.md"
 document_type: "curriculum"
+subsection: "title-page"
 ---
 # From Garden to Growth (FG2G)
 

--- a/02-introduction/from-a-garden-growth.md
+++ b/02-introduction/from-a-garden-growth.md
@@ -3,6 +3,7 @@ title: "Introduction: From a Garden to Growth"
 section: "Introduction"
 source_path: "02-introduction/from-a-garden-growth.md"
 document_type: "curriculum"
+subsection: "origin-story"
 ---
 # Introduction: From a Garden to Growth
 

--- a/02-introduction/theoretical-rationale.md
+++ b/02-introduction/theoretical-rationale.md
@@ -3,6 +3,7 @@ title: "Theoretical Rationale"
 section: "Introduction"
 source_path: "02-introduction/theoretical-rationale.md"
 document_type: "curriculum"
+subsection: "theoretical-rationale"
 ---
 # Theoretical Rationale
 

--- a/02-introduction/why-this-curriculum.md
+++ b/02-introduction/why-this-curriculum.md
@@ -3,6 +3,7 @@ title: "Why This Curriculum"
 section: "Introduction"
 source_path: "02-introduction/why-this-curriculum.md"
 document_type: "curriculum"
+subsection: "rationale"
 ---
 # Why This Curriculum
 

--- a/05-grade-bands/3-5/part-1.md
+++ b/05-grade-bands/3-5/part-1.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/3-5/part-1.md"
 document_type: "curriculum"
 subsection: "3-5"
+phase: "Root"
+framework_question: "Am I safe and ready to learn?"
+duration: "5-7 minutes"
 ---
 # 3-5 Root Phase: Student-Selected Grounding
 

--- a/05-grade-bands/3-5/part-2.md
+++ b/05-grade-bands/3-5/part-2.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/3-5/part-2.md"
 document_type: "curriculum"
 subsection: "3-5"
+phase: "Regulate"
+framework_question: "Can I return to my window of tolerance?"
+duration: "2-15 minutes"
 ---
 # 3-5 Regulate Phase: Building Self-Regulation
 

--- a/05-grade-bands/3-5/part-3.md
+++ b/05-grade-bands/3-5/part-3.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/3-5/part-3.md"
 document_type: "curriculum"
 subsection: "3-5"
+phase: "Reflect"
+framework_question: "What am I thinking, and why?"
+duration: "20-35 minutes"
 ---
 # 3-5 Reflect Phase: Developing Metacognition
 

--- a/05-grade-bands/3-5/part-4.md
+++ b/05-grade-bands/3-5/part-4.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/3-5/part-4.md"
 document_type: "curriculum"
 subsection: "3-5"
+phase: "Restore"
+framework_question: "What can I learn from this mistake?"
+duration: "5-10 minutes"
 ---
 # 3-5 Restore Phase: Error Analysis Foundations
 

--- a/05-grade-bands/3-5/part-5.md
+++ b/05-grade-bands/3-5/part-5.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/3-5/part-5.md"
 document_type: "curriculum"
 subsection: "3-5"
+phase: "Reconnect"
+framework_question: "How does this connect to my world?"
+duration: "10-15 minutes"
 ---
 # 3-5 Reconnect Phase: Community Connections
 

--- a/05-grade-bands/6-8/part-1.md
+++ b/05-grade-bands/6-8/part-1.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/6-8/part-1.md"
 document_type: "curriculum"
 subsection: "6-8"
+phase: "Root"
+framework_question: "Am I safe and ready to learn?"
+duration: "3-5 minutes"
 ---
 # 6-8 Root Phase: Self-Assessment and Peer Grounding
 

--- a/05-grade-bands/6-8/part-2.md
+++ b/05-grade-bands/6-8/part-2.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/6-8/part-2.md"
 document_type: "curriculum"
 subsection: "6-8"
+phase: "Regulate"
+framework_question: "Can I return to my window of tolerance?"
+duration: "5-10 minutes"
 ---
 # 6-8 Regulate Phase: Independent Regulation Skills
 

--- a/05-grade-bands/6-8/part-3.md
+++ b/05-grade-bands/6-8/part-3.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/6-8/part-3.md"
 document_type: "curriculum"
 subsection: "6-8"
+phase: "Reflect"
+framework_question: "What am I thinking, and why?"
+duration: "20-35 minutes"
 ---
 # 6-8 Reflect Phase: Full TRACE Implementation
 

--- a/05-grade-bands/6-8/part-4.md
+++ b/05-grade-bands/6-8/part-4.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/6-8/part-4.md"
 document_type: "curriculum"
 subsection: "6-8"
+phase: "Restore"
+framework_question: "What can I learn from this mistake?"
+duration: "5-10 minutes"
 ---
 # 6-8 Restore Phase: Systematic Error Analysis
 

--- a/05-grade-bands/6-8/part-5.md
+++ b/05-grade-bands/6-8/part-5.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/6-8/part-5.md"
 document_type: "curriculum"
 subsection: "6-8"
+phase: "Reconnect"
+framework_question: "How does this connect to my world?"
+duration: "5-10 minutes"
 ---
 # 6-8 Reconnect Phase: Community Application Projects
 

--- a/05-grade-bands/9-12/part-1.md
+++ b/05-grade-bands/9-12/part-1.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/9-12/part-1.md"
 document_type: "curriculum"
 subsection: "9-12"
+phase: "Root"
+framework_question: "Am I safe and ready to learn?"
+duration: "2-5 minutes"
 ---
 # 9-12 Root Phase: Self-Directed Grounding
 

--- a/05-grade-bands/9-12/part-2.md
+++ b/05-grade-bands/9-12/part-2.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/9-12/part-2.md"
 document_type: "curriculum"
 subsection: "9-12"
+phase: "Regulate"
+framework_question: "Can I return to my window of tolerance?"
+duration: "2-5 minutes"
 ---
 # 9-12 Regulate Phase: Proactive Self-Regulation
 

--- a/05-grade-bands/9-12/part-3.md
+++ b/05-grade-bands/9-12/part-3.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 source_path: "05-grade-bands/9-12/part-3.md"
 document_type: "curriculum"
 subsection: "9-12"
+phase: "Reflect"
+framework_question: "What am I thinking, and why?"
+duration: "15-25 minutes"
 ---
 # 9-12 Reflect Phase: Advanced Reasoning and Problem Posing
 

--- a/05-grade-bands/9-12/part-4.md
+++ b/05-grade-bands/9-12/part-4.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 subsection: "9-12"
 source_path: "05-grade-bands/9-12/part-4.md"
 document_type: "curriculum"
+phase: "Restore"
+framework_question: "What can I learn from this mistake?"
+duration: "15-25 minutes"
 ---
 # Grade Band 9-12: Restore Phase — Metacognitive Error Mastery
 

--- a/05-grade-bands/9-12/part-5.md
+++ b/05-grade-bands/9-12/part-5.md
@@ -4,6 +4,9 @@ section: "Grade Bands"
 subsection: "9-12"
 source_path: "05-grade-bands/9-12/part-5.md"
 document_type: "curriculum"
+phase: "Reconnect"
+framework_question: "How does this connect to my world?"
+duration: "variable"
 ---
 # Grade Band 9-12: Reconnect Phase — Real-World Enterprise and Leadership
 

--- a/05-grade-bands/README.md
+++ b/05-grade-bands/README.md
@@ -21,6 +21,12 @@ The grade bands are the heart of the FG2G curriculum. While the [5Rs Framework](
 | [6-8](6-8/) | 11-14 | Self-assessment and peer grounding, numeric regulation scales, independent strategy menus, community application | `6-8/` |
 | [9-12](9-12/) | 14-18 | Self-directed grounding, personal grounding plans, mentorship roles, garden-to-community enterprise | `9-12/` |
 
+### Additional Resources
+
+| Document | Description |
+|----------|-------------|
+| [Transition Guide](transition-guide.md) | Guidance for managing student transitions between grade bands, onboarding new students, and monitoring transition success |
+
 ## Structure Within Each Grade Band
 
 Each grade band contains five parts aligned with the 5Rs phases:

--- a/05-grade-bands/transition-guide.md
+++ b/05-grade-bands/transition-guide.md
@@ -1,0 +1,167 @@
+---
+title: "Grade Band Transition Guide"
+section: "Grade Bands"
+source_path: "05-grade-bands/transition-guide.md"
+document_type: "curriculum"
+subsection: "transitions"
+---
+# Grade Band Transition Guide
+
+## Purpose
+
+This guide supports educators, counselors, and administrators in managing student transitions between grade bands (K-2 to 3-5, 3-5 to 6-8, 6-8 to 9-12). Each transition shifts the balance of responsibility from adult to student, introduces new tools and protocols, and raises expectations for self-regulation and metacognition. Without intentional planning, these transitions can disrupt the felt safety and predictable structure that trauma-informed practice requires.
+
+---
+
+## Transition 1: K-2 to 3-5 (Ages 7-9)
+
+### What Changes
+
+| Dimension | K-2 Approach | 3-5 Approach | Transition Strategy |
+|-----------|-------------|-------------|---------------------|
+| **Check-In** | Picture cards (weather imagery), adult-directed | Student-selected format (verbal, written, drawing) | Introduce choice gradually in spring of 2nd grade; offer 2 options before full menu |
+| **Regulation Scale** | Observational (educator reads body language) | Numeric 1-5 with garden imagery (self-report) | Practice the 1-5 scale alongside picture cards for a full quarter before switching |
+| **Regulation Support** | Adult-led co-regulation (breathing buddies, songs) | Regulation Toolbox (student-selected strategies) | Begin building a personal toolbox in late 2nd grade with 3-4 familiar strategies |
+| **Error Response** | "Oops and Grow" (concrete, joyful) | Brain Growth Moments (structured journaling) | Introduce the journal format while keeping "Oops and Grow" language available |
+| **Journaling** | Drawing with labels/dictation | Written entries with sentence starters | Shift from drawing-primary to writing-primary across 2nd grade spring |
+| **TRACE Protocol** | Educator-modeled think-alouds | Scaffolded student use with prompt cards | Introduce the Think and Reason steps as vocabulary in late K-2 |
+
+### Educator Actions for Spring of 2nd Grade
+
+1. **Introduce the regulation scale**: Post the 1-5 garden scale alongside weather cards. Let students use either system.
+2. **Begin choice-based check-ins**: "Today you can tell me, write it, or draw it."
+3. **Model TRACE vocabulary**: Use "Think" and "Reason" as verbs during garden activities without requiring student use.
+4. **Start a simple toolbox**: Each student identifies 2-3 strategies that help them regulate. Record these on a card.
+5. **Practice written check-ins**: Provide sentence starters for journal entries alongside drawing options.
+
+### Educator Actions for Fall of 3rd Grade
+
+1. **Honor prior learning**: "You already know how to check in with your body -- we used weather cards. Now you have even more ways to do that."
+2. **Expect a regression period**: Some students will need picture cards temporarily. Keep them available without comment.
+3. **Build slowly**: Introduce one new element per week rather than changing everything on day one.
+4. **Maintain rituals**: Keep the garden entry routine consistent even as check-in methods evolve.
+
+---
+
+## Transition 2: 3-5 to 6-8 (Ages 10-12)
+
+### What Changes
+
+| Dimension | 3-5 Approach | 6-8 Approach | Transition Strategy |
+|-----------|-------------|-------------|---------------------|
+| **Check-In** | Student-selected format with 1-5 scale | Numeric self-rating (0-100) | Introduce the expanded scale in spring of 5th grade; practice self-rating accuracy |
+| **Regulation** | Regulation Toolbox with educator prompting | Independent strategy selection, peer partnerships | Formalize peer partnerships in late 5th grade; reduce prompting frequency |
+| **TRACE Protocol** | Scaffolded with prompt cards and educator modeling | Full independent use of all 5 steps | Withdraw prompt cards gradually; expect independent use by end of 5th grade |
+| **Reasoning Moves** | Introduced with anchor activities; prompted by educator | All 7 moves used fluently; student-initiated | Students should be able to name all 7 moves by end of 5th grade |
+| **Error Analysis** | 3 error types (computational, procedural, conceptual) | 5 error types (add strategic and reading/interpretation) | Introduce the two new types in spring of 5th grade using familiar garden contexts |
+| **Portfolio** | Educator-guided selection; basic reflections | Student-curated with substantive reflections | Practice portfolio self-selection and written reflection in 5th grade |
+| **Community Projects** | Educator-designed with student input | Student-designed with educator guidance | Let 5th graders propose project ideas even if educators refine them |
+
+### Educator Actions for Spring of 5th Grade
+
+1. **Expand the regulation scale**: Introduce 0-100 alongside the 1-5 scale. "If 5 is 100 and 1 is 0, where are you right now on the full scale?"
+2. **Formalize peer partnerships**: Assign regulation partners and teach the Notice-Offer-Respect protocol.
+3. **Withdraw TRACE scaffolding**: Stop distributing prompt cards; ask students to recall steps from memory.
+4. **Introduce the five error types**: Teach strategic and reading/interpretation errors using garden-based scenarios.
+5. **Student-led portfolio selection**: Let students choose which work to include and write their own reflections.
+
+### Educator Actions for Fall of 6th Grade
+
+1. **Validate the transition**: "Middle school is a big change. The 5Rs are the same structure you've used for years -- they still work."
+2. **Expect identity sensitivity**: Adolescents may resist practices perceived as "childish." Frame everything in mature language.
+3. **Emphasize peer support**: The peer grounding partnership model aligns with adolescent social needs.
+4. **Provide quiet options**: Some students will want to ground silently. Respect this as a valid, mature strategy.
+5. **Increase autonomy gradually**: Start with structured choice and expand independence across the first quarter.
+
+---
+
+## Transition 3: 6-8 to 9-12 (Ages 13-15)
+
+### What Changes
+
+| Dimension | 6-8 Approach | 9-12 Approach | Transition Strategy |
+|-----------|-------------|-------------|---------------------|
+| **Check-In** | Numeric self-rating with educator monitoring | Self-directed Personal Grounding Plan (PGP) | Begin PGP development in spring of 8th grade |
+| **Regulation** | Independent strategy selection with peer partnerships | Fully autonomous; mentorship of younger students | Assign 8th graders as mentors to 6th graders for one quarter |
+| **TRACE Protocol** | Full independent use | Student-directed; students pose their own problems | Practice problem-posing in 8th grade research projects |
+| **Reasoning Moves** | All 7 used fluently with prompting as needed | All 7 used autonomously; students identify moves in others' work | Students lead reasoning move discussions in 8th grade |
+| **Error Analysis** | Systematic with 5 error types | Metacognitive error mastery; independent analysis | Students conduct full error analyses independently by end of 8th grade |
+| **Portfolio** | Student-curated with substantive reflections | Capstone portfolio with reflective synthesis | Practice reflective synthesis essays in 8th grade |
+| **Community** | Student-designed projects with educator guidance | Garden-to-community enterprise; authentic leadership | Involve 8th graders in planning next year's enterprise as a preview |
+| **Educator Role** | Collaborative coach | Available consultant | Shift language toward consultation in spring of 8th grade |
+
+### Educator Actions for Spring of 8th Grade
+
+1. **Draft a Personal Grounding Plan**: Each student creates a preliminary PGP listing their top strategies, signals, and preferences.
+2. **Assign mentorship**: Pair 8th graders with younger students for grounding guidance. Teach active listening and age-appropriate communication.
+3. **Practice problem-posing**: During Reflect phase, ask students to generate the investigation questions rather than answering given ones.
+4. **Independent error analysis**: Withdraw educator guidance during Restore and see if students can self-diagnose errors.
+5. **Enterprise preview**: Share examples of 9-12 enterprise projects. Let 8th graders brainstorm what they might create.
+
+### Educator Actions for Fall of 9th Grade
+
+1. **Trust student self-knowledge**: "You know yourself better than anyone. Your grounding plan is yours to use."
+2. **Introduce garden leadership roles**: Garden Manager, Soil Scientist, Irrigation Engineer, Harvest Coordinator, Mentorship Liaison.
+3. **Frame enterprise early**: Begin community needs mapping in the first month.
+4. **Maintain safety**: Despite increased autonomy, the Root phase is non-negotiable. Every session begins with grounding, even if student-directed.
+5. **Name the trajectory**: "You've been building these skills since kindergarten. Now you're ready to lead with them."
+
+---
+
+## Students New to the 5Rs Framework
+
+Students who enter at any grade band without prior 5Rs experience require intentional onboarding. They cannot be expected to operate at the autonomy level of students who have been building these skills for years.
+
+### Onboarding Protocol
+
+| Student Entry Point | Onboarding Duration | Key Actions |
+|-------------------|--------------------| ------------|
+| Entering 3-5 without K-2 experience | 4-6 weeks | Teach the regulation scale explicitly; introduce picture cards temporarily; build a toolbox from scratch |
+| Entering 6-8 without prior experience | 6-8 weeks | Teach self-assessment with adult calibration; introduce TRACE one step at a time; assign a regulation partner from day one |
+| Entering 9-12 without prior experience | 8-10 weeks | Provide a structured grounding menu (not self-directed); introduce all 5Rs phases explicitly; delay mentorship until the student has internalized the framework |
+
+### Guiding Principles for New Students
+
+- **Meet them where they are**, not where the grade band assumes they should be.
+- **Avoid assumptions** about what they should already know. Trauma histories may have prevented prior exposure to SEL programming.
+- **Use lower-band scaffolding** without infantilizing. A 9th grader can use a grounding menu without it feeling like a kindergarten exercise if the language is mature.
+- **Build trust first**. The Root phase may be the most critical investment for a new student. Extend it as long as needed.
+- **Assign a peer buddy** who can model the framework naturally rather than explaining it didactically.
+
+---
+
+## Monitoring Transition Success
+
+### Indicators That a Transition Is Going Well
+
+- Student uses new tools (expanded scale, TRACE without cards, PGP) with increasing fluency
+- Regulation episodes decrease in frequency and duration across the first quarter
+- Student voluntarily references prior-band skills ("This is like when we used to...")
+- Portfolio reflections show awareness of growth across bands
+- Student expresses ownership of the process ("I know what works for me")
+
+### Indicators That Additional Support Is Needed
+
+- Student reverts to lower-band behaviors (requesting picture cards in 6th grade, needing adult-directed regulation in 9th grade)
+- Regulation episodes increase or intensify after the transition
+- Student expresses shame about needing support ("I should be past this by now")
+- Academic performance drops despite adequate content preparation
+- Student withdraws from peer partnerships or community engagement
+
+### Response to Transition Difficulty
+
+1. **Normalize**: "Transitions are hard. Your brain is adjusting to new expectations. That takes time."
+2. **Scaffold temporarily**: Reintroduce lower-band supports without labeling them as regression.
+3. **Check for triggers**: Transition difficulty may signal a new or intensified trauma response, not just adjustment.
+4. **Communicate across bands**: The sending and receiving educators should share relevant regulation data and strategies.
+5. **Adjust timeline**: Some students need a full semester, not just a quarter, to fully transition.
+
+---
+
+## Navigation
+
+- [Back to Grade Bands Overview](README.md)
+- [K-2 Grade Band](K-2/)
+- [3-5 Grade Band](3-5/)
+- [6-8 Grade Band](6-8/)
+- [9-12 Grade Band](9-12/)


### PR DESCRIPTION
… guide

- Add phase, framework_question, and duration fields to YAML frontmatter across all 15 grade band files (3-5, 6-8, 9-12) to match K-2 standard
- Add subsection field to all 9 front-matter and introduction files for consistent metadata across curriculum sections
- Create cross-grade-band transition guide covering K-2→3-5, 3-5→6-8, and 6-8→9-12 transitions with educator action plans, onboarding protocol for new students, and monitoring indicators
- Update grade bands README to reference the transition guide

https://claude.ai/code/session_01Ef8caw1hvRMcBZ4sbp4mh3