### PR TITLE
Harden tenant isolation checks and add multi-tenant RLS-style integration tests

### DIFF
--- a/src/app/api/educator/students/route.ts
+++ b/src/app/api/educator/students/route.ts
@@ -18,9 +18,21 @@ export async function GET(req: NextRequest) {
   const pageSize = Math.min(parseInt(req.nextUrl.searchParams.get('pageSize') ?? '30', 10), 100);
   const skip = (page - 1) * pageSize;
 
-  const whereClause = classId
-    ? { enrollments: { some: { classId } } }
-    : { user: { tenantId: user.tenantId } };
+  if (classId) {
+    const targetClass = await db.class.findUnique({
+      where: { id: classId },
+      select: { tenantId: true },
+    });
+
+    if (!targetClass || targetClass.tenantId !== user.tenantId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+  }
+
+  const whereClause = {
+    user: { tenantId: user.tenantId },
+    ...(classId ? { enrollments: { some: { classId } } } : {}),
+  };
 
   const [students, total] = await Promise.all([
     db.student.findMany({

--- a/tests/integration/api/educator-students.test.ts
+++ b/tests/integration/api/educator-students.test.ts
@@ -10,6 +10,9 @@ vi.mock('@/lib/db', () => ({
     user: {
       findUnique: vi.fn(),
     },
+    class: {
+      findUnique: vi.fn(),
+    },
     student: {
       findMany: vi.fn(),
       count: vi.fn(),
@@ -74,6 +77,7 @@ describe('GET /api/educator/students', () => {
     ];
 
     vi.mocked(db.student.findMany).mockResolvedValueOnce(mockStudents as any);
+    vi.mocked(db.class.findUnique).mockResolvedValueOnce({ tenantId: 'tenant_123' } as any);
     vi.mocked(db.student.count).mockResolvedValueOnce(2);
 
     const { GET } = await import('@/app/api/educator/students/route');
@@ -96,6 +100,7 @@ describe('GET /api/educator/students', () => {
       tenantId: 'tenant_123',
       role: 'EDUCATOR',
     } as any);
+    vi.mocked(db.class.findUnique).mockResolvedValueOnce({ tenantId: 'tenant_123' } as any);
     vi.mocked(db.student.findMany).mockResolvedValueOnce([{
       id: 'student_1',
       user: { id: 'user_1', firstName: 'Alice', lastName: 'Smith', email: 'alice@test.com' },
@@ -112,11 +117,40 @@ describe('GET /api/educator/students', () => {
 
     expect(response.status).toBe(200);
     expect(data.data).toHaveLength(1);
+    expect(db.class.findUnique).toHaveBeenCalledWith({
+      where: { id: 'class_123' },
+      select: { tenantId: true },
+    });
     expect(db.student.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { enrollments: { some: { classId: 'class_123' } } },
+        where: {
+          user: { tenantId: 'tenant_123' },
+          enrollments: { some: { classId: 'class_123' } },
+        },
       })
     );
+  });
+
+
+
+  it('returns 403 when classId belongs to a different tenant', async () => {
+    const { db } = await import('@/lib/db');
+    vi.mocked(db.user.findUnique).mockResolvedValueOnce({
+      id: 'educator_123',
+      clerkUserId: 'clerk_educator_123',
+      tenantId: 'tenant_123',
+      role: 'EDUCATOR',
+    } as any);
+    vi.mocked(db.class.findUnique).mockResolvedValueOnce({ tenantId: 'tenant_other' } as any);
+
+    const { GET } = await import('@/app/api/educator/students/route');
+    const req = new NextRequest('http://localhost:3000/api/educator/students?classId=class_other');
+
+    const response = await GET(req);
+
+    expect(response.status).toBe(403);
+    expect(db.student.findMany).not.toHaveBeenCalled();
+    expect(db.student.count).not.toHaveBeenCalled();
   });
 
   it('respects pagination parameters', async () => {

--- a/tests/integration/api/multi-tenant-rls-audit.test.ts
+++ b/tests/integration/api/multi-tenant-rls-audit.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(() => ({ userId: 'clerk_teacher_school_b' })),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    class: {
+      findUnique: vi.fn(),
+    },
+    student: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+    session: {
+      findUnique: vi.fn(),
+    },
+    assessment: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/redis/cached-queries', () => ({
+  getCachedUserProfile: vi.fn(),
+  getCachedSession: vi.fn(),
+  invalidateSessionCache: vi.fn(),
+}));
+
+describe('Multi-tenant isolation audit (RLS-style negative paths)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('profiles: blocks School B teacher from listing School A class roster', async () => {
+    const { db } = await import('@/lib/db');
+
+    vi.mocked(db.user.findUnique).mockResolvedValueOnce({
+      id: 'teacher_b',
+      clerkUserId: 'clerk_teacher_school_b',
+      tenantId: 'school_b',
+      role: 'EDUCATOR',
+    } as any);
+
+    vi.mocked(db.class.findUnique).mockResolvedValueOnce({
+      tenantId: 'school_a',
+    } as any);
+
+    const { GET } = await import('@/app/api/educator/students/route');
+    const req = new NextRequest('http://localhost:3000/api/educator/students?classId=class_school_a');
+
+    const response = await GET(req);
+
+    expect(response.status).toBe(403);
+    expect(db.student.findMany).not.toHaveBeenCalled();
+    expect(db.student.count).not.toHaveBeenCalled();
+  });
+
+  it('assignments: blocks School B teacher from reading School A session assessments', async () => {
+    const { db } = await import('@/lib/db');
+
+    vi.mocked(db.session.findUnique).mockResolvedValueOnce({
+      id: 'session_school_a',
+      tenantId: 'school_a',
+      student: { userId: 'student_user_a' },
+    } as any);
+
+    vi.mocked(db.user.findUnique).mockResolvedValueOnce({
+      id: 'teacher_b',
+      clerkUserId: 'clerk_teacher_school_b',
+      tenantId: 'school_b',
+      role: 'EDUCATOR',
+    } as any);
+
+    const { GET } = await import('@/app/api/assessments/route');
+    const req = new NextRequest('http://localhost:3000/api/assessments?sessionId=session_school_a');
+
+    const response = await GET(req);
+
+    expect(response.status).toBe(403);
+    expect(db.assessment.findMany).not.toHaveBeenCalled();
+  });
+
+  it('chats: blocks School B teacher token from School A student chat session', async () => {
+    const { getCachedUserProfile, getCachedSession } = await import('@/lib/redis/cached-queries');
+
+    vi.mocked(getCachedUserProfile).mockResolvedValueOnce({
+      id: 'teacher_b',
+      tenantId: 'school_b',
+      student: {
+        id: 'student_b',
+        gradeLevel: 6,
+        learningPreferences: {},
+        iepAccommodations: [],
+      },
+    } as any);
+
+    vi.mocked(getCachedSession).mockResolvedValueOnce({
+      id: 'session_school_a',
+      tenantId: 'school_a',
+      studentId: 'student_a',
+      endedAt: null,
+      messages: [],
+      regulationState: { level: 70 },
+      subject: 'MATH',
+      engagementMode: 'FORWARD',
+    } as any);
+
+    const { POST } = await import('@/app/api/chat/route');
+    const req = new NextRequest('http://localhost:3000/api/chat', {
+      method: 'POST',
+      body: JSON.stringify({ sessionId: 'session_school_a', message: 'hello' }),
+    });
+
+    const response = await POST(req);
+
+    expect(response.status).toBe(403);
+  });
+});


### PR DESCRIPTION
### Motivation

- Ensure strict cross-tenant data isolation for school tenants and close a gap where a foreign `classId` could bypass tenant scoping.  
- Provide explicit negative-path integration coverage that simulates a "School B" actor attempting to access "School A" data to validate RLS-like behavior.  

### Description

- Tightened `GET /api/educator/students` by verifying the requested `classId` belongs to the authenticated user's tenant before performing any student queries and by always scoping student queries to `user.tenantId`.  
- Updated `tests/integration/api/educator-students.test.ts` to mock `db.class.findUnique`, assert the class tenant check, and validate the revised `where` composition and negative path for foreign-tenant `classId`.  
- Added a new integration audit suite `tests/integration/api/multi-tenant-rls-audit.test.ts` that asserts cross-tenant access is denied for profiles (roster), assignments (assessments), and chats.  

### Testing

- Attempted to run the new/updated integration tests with `npm run test -- tests/integration/api/educator-students.test.ts tests/integration/api/multi-tenant-rls-audit.test.ts`, but the runnable `vitest` binary was not present in the environment so tests did not execute.  
- Attempted `npx --yes vitest run ...` to run the tests, but execution was blocked by package registry access (`403 Forbidden`), preventing automated test execution in this environment.  
- All changes include unit/integration test files and mocks ready to run in a developer environment with network/package access and dependencies installed (`npm install` / `npm ci`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c3e80b58832a910cd200e23de7bc)