### PR TITLE
hotfix: Add missing IRT/SRS model definitions to schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -225,6 +225,157 @@ enum AccommodationType {
 }
 
 // ═══════════════════════════════════════════════════════════════
+// ITEM RESPONSE THEORY (IRT) MODELS
+// ═══════════════════════════════════════════════════════════════
+
+model ItemCalibration {
+  id                String      @id @default(cuid())
+  assessmentId      String?     @unique
+  assessment        Assessment? @relation(fields: [assessmentId], references: [id])
+  problemId         String?     @unique
+  problem           Problem?    @relation(fields: [problemId], references: [id])
+  itemType          ItemType    @default(ASSESSMENT)
+  irtDifficulty     Float // b parameter (-3 to +3 logit scale)
+  irtDiscrimination Float       @default(1.0) // a parameter (0 to 2.5+)
+  irtGuessing       Float       @default(0.0) // c parameter for 3PL (0 to 0.5)
+  calibrationModel  IRTModel    @default(TWO_PL)
+  sampleSize        Int         @default(0) // responses used for calibration
+  standardError     Float?
+  itemInformation   Float? // peak information value
+  reliabilityIndex  Float? // 0 to 1
+  lastCalibratedAt  DateTime?
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+
+  @@index([irtDifficulty])
+  @@index([itemType])
+}
+
+enum ItemType {
+  ASSESSMENT
+  PROBLEM
+}
+
+enum IRTModel {
+  ONE_PL // Rasch model
+  TWO_PL // 2-parameter logistic
+  THREE_PL // 3-parameter logistic
+}
+
+model StudentAbility {
+  id                      String   @id @default(cuid())
+  studentId               String
+  student                 Student  @relation(fields: [studentId], references: [id])
+  subject                 Subject
+  currentTheta            Float // ability estimate (-3 to +3 logit scale)
+  standardError           Float
+  confidenceIntervalLower Float
+  confidenceIntervalUpper Float
+  reliabilityIndex        Float // 0 to 1
+  assessmentCount         Int      @default(0)
+  lastEstimatedAt         DateTime @default(now())
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
+
+  @@unique([studentId, subject])
+  @@index([studentId])
+  @@index([subject])
+}
+
+model ResponseData {
+  id                   String     @id @default(cuid())
+  assessmentId         String
+  assessment           Assessment @relation(fields: [assessmentId], references: [id])
+  studentId            String
+  itemCalibrationId    String?
+  isCorrect            Boolean
+  responseTime         Int? // milliseconds
+  probabilityPredicted Float? // from ICC
+  residual             Float? // observed - predicted
+  studentTheta         Float? // theta at time of response
+  createdAt            DateTime   @default(now())
+
+  @@index([assessmentId])
+  @@index([studentId])
+  @@index([itemCalibrationId])
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SPACED REPETITION SYSTEM (SRS) MODELS - FSRS Algorithm
+// ═══════════════════════════════════════════════════════════════
+
+model ReviewSchedule {
+  id             String          @id @default(cuid())
+  studentId      String
+  student        Student         @relation(fields: [studentId], references: [id])
+  conceptType    ConceptType
+  standardId     String?
+  standard       Standard?       @relation(fields: [standardId], references: [id])
+  topicId        String?
+  topic          Topic?          @relation(fields: [topicId], references: [id])
+  problemId      String?
+  problem        Problem?        @relation(fields: [problemId], references: [id])
+  state          ReviewState     @default(NEW)
+  stability      Float           @default(0.0) // FSRS: memory stability (days)
+  difficulty     Float           @default(5.0) // FSRS: item difficulty (0-10)
+  elapsedDays    Int             @default(0)
+  scheduledDays  Int             @default(0)
+  dueDate        DateTime
+  lastReviewDate DateTime?
+  lapses         Int             @default(0) // times forgotten
+  reps           Int             @default(0) // total reviews
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  reviewHistory  ReviewHistory[]
+
+  @@unique([studentId, conceptType, standardId, topicId, problemId])
+  @@index([studentId])
+  @@index([studentId, dueDate])
+  @@index([dueDate])
+  @@index([state])
+}
+
+enum ConceptType {
+  STANDARD
+  TOPIC
+  PROBLEM
+}
+
+enum ReviewState {
+  NEW // Never reviewed
+  LEARNING // In initial learning phase
+  REVIEW // In review phase
+  RELEARNING // Forgotten, being relearned
+}
+
+model ReviewHistory {
+  id                 String         @id @default(cuid())
+  scheduleId         String
+  schedule           ReviewSchedule @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
+  rating             ReviewRating
+  state              ReviewState
+  reviewedAt         DateTime       @default(now())
+  elapsedDays        Int
+  scheduledDays      Int
+  previousStability  Float
+  newStability       Float
+  previousDifficulty Float
+  newDifficulty      Float
+  responseTime       Int? // milliseconds
+  createdAt          DateTime       @default(now())
+
+  @@index([scheduleId])
+  @@index([reviewedAt])
+}
+
+enum ReviewRating {
+  AGAIN // Completely forgot (1)
+  HARD // Remembered with difficulty (2)
+  GOOD // Remembered correctly (3)
+  EASY // Remembered easily (4)
+}
+
+// ═══════════════════════════════════════════════════════════════
 // SESSION & MESSAGE MODELS
 // ═══════════════════════════════════════════════════════════════
 
@@ -249,13 +400,13 @@ model Session {
 }
 
 model Message {
-  id                   String                 @id @default(cuid())
-  sessionId            String
-  session              Session                @relation(fields: [sessionId], references: [id])
-  role                 MessageRole
-  content              String                 @db.Text
-  metadata             Json?
-  createdAt            DateTime               @default(now())
+  id                    String                 @id @default(cuid())
+  sessionId             String
+  session               Session                @relation(fields: [sessionId], references: [id])
+  role                  MessageRole
+  content               String                 @db.Text
+  metadata              Json?
+  createdAt             DateTime               @default(now())
   nvcQualityEvaluations NVCQualityEvaluation[]
 }
 
@@ -624,38 +775,38 @@ enum IngestSource {
 // ═══════════════════════════════════════════════════════════════
 
 model NVCQualityEvaluation {
-  id                 String         @id @default(cuid())
-  messageId          String
-  message            Message        @relation(fields: [messageId], references: [id])
-  sessionId          String
-  tenantId           String
-  evaluatedAt        DateTime       @default(now())
+  id          String   @id @default(cuid())
+  messageId   String
+  message     Message  @relation(fields: [messageId], references: [id])
+  sessionId   String
+  tenantId    String
+  evaluatedAt DateTime @default(now())
 
   // Evaluation results
-  isCompliant        Boolean
-  nvcScore           Float          // 0-100 score
-  concerns           NVCConcern[]
+  isCompliant Boolean
+  nvcScore    Float // 0-100 score
+  concerns    NVCConcern[]
 
   // Detailed analysis
   judgmentalPhrases  String[]
   dismissivePhrases  String[]
-  suggestedRevisions String[]       @db.Text
+  suggestedRevisions String[] @db.Text
 
   // LLM analysis metadata
-  rawAnalysis        String         @db.Text
-  llmModel           String
-  llmTokens          Int
-  llmLatencyMs       Int
+  rawAnalysis  String @db.Text
+  llmModel     String
+  llmTokens    Int
+  llmLatencyMs Int
 
   // Review status
-  reviewStatus       ReviewStatus   @default(PENDING)
-  reviewedBy         String?
-  reviewedAt         DateTime?
-  reviewNotes        String?        @db.Text
+  reviewStatus ReviewStatus @default(PENDING)
+  reviewedBy   String?
+  reviewedAt   DateTime?
+  reviewNotes  String?      @db.Text
 
   // Admin actions
-  adminAction        AdminAction?
-  actionTakenAt      DateTime?
+  adminAction   AdminAction?
+  actionTakenAt DateTime?
 
   @@index([messageId])
   @@index([sessionId])


### PR DESCRIPTION
The merge to main (PR #108) lost the model definitions for ItemCalibration, StudentAbility, ResponseData, ReviewSchedule, and ReviewHistory. The relations were added to existing models but the model definitions themselves were missing, causing Prisma validation errors.

This hotfix:
1. Adds all IRT/SRS model definitions
2. Places them BEFORE the SESSION & MESSAGE MODELS section
3. Ensures models are defined before being referenced

Fixes build error:
- P1012: Type "StudentAbility" is neither a built-in type...
- P1012: Type "ReviewSchedule" is neither a built-in type...
- P1012: Type "ItemCalibration" is neither a built-in type...
- P1012: Type "ResponseData" is neither a built-in type...

Models added:
- ItemCalibration (with ItemType, IRTModel enums)
- StudentAbility
- ResponseData
- ReviewSchedule (with ConceptType, ReviewState enums)
- ReviewHistory (with ReviewRating enum)

https://claude.ai/code/session_0178JQCKdFgHpziCZfcbqXyT