### PR TITLE
Fix missing auth-helpers module import errors

### DIFF
--- a/src/app/api/admin/data-retention/route.ts
+++ b/src/app/api/admin/data-retention/route.ts
@@ -10,7 +10,7 @@ import {
   getRetentionStatistics,
 } from '@/lib/compliance/data-retention';
 import { logger } from '@/lib/logger';
-import { getUserFromClerkId } from '@/lib/auth-helpers';
+import { getUserFromClerkId } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 

--- a/src/app/api/parent/students/route.ts
+++ b/src/app/api/parent/students/route.ts
@@ -6,7 +6,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { prisma } from '@/lib/db';
-import { getUserFromClerkId } from '@/lib/auth-helpers';
+import { getUserFromClerkId } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -33,3 +33,10 @@ export async function requireRole(roles: string[]) {
   }
   return user;
 }
+
+export async function getUserFromClerkId(clerkId: string) {
+  const user = await db.user.findUnique({
+    where: { clerkUserId: clerkId },
+  });
+  return user;
+}


### PR DESCRIPTION
Added getUserFromClerkId function to auth.ts and updated imports in API routes to resolve build failures.

- Added getUserFromClerkId function to src/lib/auth.ts
- Updated import in src/app/api/admin/data-retention/route.ts
- Updated import in src/app/api/parent/students/route.ts

This fixes the "Module not found: Can't resolve '@/lib/auth-helpers'" error that was causing the build to fail.

https://claude.ai/code/session_017dWhVgpF8GzUPmK2w9wuSx