### PR TITLE
Use block-style ESLint disable for emoji function

### DIFF
--- a/src/lib/monitoring/alerts.ts
+++ b/src/lib/monitoring/alerts.ts
@@ -331,7 +331,7 @@ function formatAlertMessage(alert: AlertRule, value: number, context?: Record<st
  * Note: Emojis are used here for internal monitoring/alerting (Slack, PagerDuty)
  * and are not part of the user-facing production UI
  */
-// eslint-disable-next-line no-restricted-syntax
+/* eslint-disable no-restricted-syntax */
 function getSeverityEmoji(severity: AlertSeverity): string {
   switch (severity) {
     case AlertSeverity.CRITICAL:
@@ -344,6 +344,7 @@ function getSeverityEmoji(severity: AlertSeverity): string {
       return 'ℹ️';
   }
 }
+/* eslint-enable no-restricted-syntax */
 
 /**
  * Format metric value for display


### PR DESCRIPTION
The previous single-line disable only covered the function declaration, not the emoji returns inside the function. Using block-style disable/enable to properly suppress the no-restricted-syntax rule for internal monitoring emojis.

https://claude.ai/code/session_01V6D2ibDhLcdcvZVPicNFBQ