### PR TITLE
Add idempotent FINLIT chapter seeding and curriculum filter support

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -420,6 +420,7 @@ enum Subject {
   MATH
   SCIENCE
   LANGUAGE_ARTS
+  FINANCIAL_LITERACY
 }
 
 enum FiveRPhase {
@@ -619,6 +620,7 @@ model Topic {
   commonMisconceptions    String[]
   realWorldConnections    String[]
   estimatedDuration       Int
+  fiveRsAlignment         Json?
   embedding               Bytes?
   createdAt               DateTime            @default(now())
   updatedAt               DateTime            @updatedAt

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -424,6 +424,186 @@ async function main() {
     console.log(`✅ Topic created: ${topic.name}`);
   }
 
+
+  // ═══════════════════════════════════════════════════════════════
+  // 7.5 CREATE FINANCIAL LITERACY TOPICS (Ch. I-XII)
+  // ═══════════════════════════════════════════════════════════════
+  console.log('Creating financial literacy topics...');
+
+  const finlitTopics = [
+    {
+      key: 'finlit-ch-i-income-career-planning',
+      name: 'Ch. I: Income and Career Planning',
+      learningObjectives: [
+        'Explain how education and career choices influence lifetime income.',
+        'Compare salary, wages, and gig income including tradeoffs.',
+      ],
+      fiveRsAlignment: { ROOT: 'Career identity and goals', REFLECT: 'Income decision making' },
+    },
+    {
+      key: 'finlit-ch-ii-budgeting-cash-flow',
+      name: 'Ch. II: Budgeting and Cash Flow',
+      learningObjectives: [
+        'Create a monthly zero-based budget using fixed and variable expenses.',
+        'Analyze spending patterns and adjust categories to meet savings goals.',
+      ],
+      fiveRsAlignment: { REGULATE: 'Impulse spending awareness', RESTORE: 'Budget review cycle' },
+    },
+    {
+      key: 'finlit-ch-iii-banking-services',
+      name: 'Ch. III: Banking and Financial Services',
+      learningObjectives: [
+        'Differentiate checking, savings, and money market accounts.',
+        'Evaluate banking fees and choose cost-effective account options.',
+      ],
+    },
+    {
+      key: 'finlit-ch-iv-saving-strategies',
+      name: 'Ch. IV: Saving and Emergency Funds',
+      learningObjectives: [
+        'Set short- and long-term savings goals using SMART criteria.',
+        'Calculate emergency fund targets based on monthly expenses.',
+      ],
+      fiveRsAlignment: { ROOT: 'Needs vs wants baseline', RECONNECT: 'Savings habits transfer' },
+    },
+    {
+      key: 'finlit-ch-v-credit-and-debt',
+      name: 'Ch. V: Credit and Debt Management',
+      learningObjectives: [
+        'Explain how credit scores are calculated and why they matter.',
+        'Compare debt repayment methods including avalanche and snowball.',
+      ],
+    },
+    {
+      key: 'finlit-ch-vi-loans-and-interest',
+      name: 'Ch. VI: Loans and Interest',
+      learningObjectives: [
+        'Compute simple and compound interest for common loan products.',
+        'Compare total borrowing costs across loan terms and rates.',
+      ],
+      fiveRsAlignment: { REFLECT: 'Cost-of-credit reasoning' },
+    },
+    {
+      key: 'finlit-ch-vii-consumer-skills',
+      name: 'Ch. VII: Consumer Skills and Smart Purchasing',
+      learningObjectives: [
+        'Use unit pricing and total cost to compare purchasing options.',
+        'Identify persuasive marketing techniques and consumer protections.',
+      ],
+    },
+    {
+      key: 'finlit-ch-viii-risk-insurance',
+      name: 'Ch. VIII: Risk Management and Insurance',
+      learningObjectives: [
+        'Explain how insurance pools risk and why deductibles affect premiums.',
+        'Match insurance products to real-world risk scenarios.',
+      ],
+      fiveRsAlignment: { REGULATE: 'Risk perception and emotional decisions' },
+    },
+    {
+      key: 'finlit-ch-ix-taxes-paychecks',
+      name: 'Ch. IX: Taxes and Paychecks',
+      learningObjectives: [
+        'Interpret paycheck components including withholdings and net pay.',
+        'Describe the purpose of major U.S. taxes and filing basics.',
+      ],
+    },
+    {
+      key: 'finlit-ch-x-investing-basics',
+      name: 'Ch. X: Investing Basics',
+      learningObjectives: [
+        'Differentiate stocks, bonds, mutual funds, and ETFs.',
+        'Explain diversification and risk-return tradeoffs for beginners.',
+      ],
+      fiveRsAlignment: { RECONNECT: 'Long-term wealth building habits' },
+    },
+    {
+      key: 'finlit-ch-xi-retirement-planning',
+      name: 'Ch. XI: Retirement and Long-Term Planning',
+      learningObjectives: [
+        'Compare retirement account options such as 401(k) and IRA.',
+        'Model the impact of starting contributions early vs later.',
+      ],
+    },
+    {
+      key: 'finlit-ch-xii-financial-decision-making',
+      name: 'Ch. XII: Financial Decision-Making and Goal Setting',
+      learningObjectives: [
+        'Apply a structured process to make major financial decisions.',
+        'Build a personal financial action plan for the next 12 months.',
+      ],
+      fiveRsAlignment: { ROOT: 'Values and priorities', RECONNECT: 'Action plan and accountability' },
+    },
+  ] as const;
+
+  for (const finlitTopic of finlitTopics) {
+    const topicId = `topic-${finlitTopic.key}`;
+
+    await prisma.topic.upsert({
+      where: { id: topicId },
+      update: {
+        name: finlitTopic.name,
+        subject: 'FINANCIAL_LITERACY',
+        gradeLevel: [9, 10, 11, 12],
+        description: `${finlitTopic.name} introduces core personal finance concepts for high school learners.`,
+        conceptualUnderstanding:
+          'Personal finance choices compound over time; informed, values-aligned decisions improve long-term outcomes.',
+        commonMisconceptions: [
+          'Financial literacy is only relevant in adulthood',
+          'Higher income alone guarantees financial stability',
+          'Small money decisions do not meaningfully affect long-term goals',
+        ],
+        realWorldConnections: [
+          'Managing paycheck-to-paycheck decisions',
+          'Comparing financial products and contracts',
+          'Planning for education, housing, and future goals',
+        ],
+        estimatedDuration: 50,
+        fiveRsAlignment: finlitTopic.fiveRsAlignment ?? null,
+      },
+      create: {
+        id: topicId,
+        name: finlitTopic.name,
+        subject: 'FINANCIAL_LITERACY',
+        gradeLevel: [9, 10, 11, 12],
+        description: `${finlitTopic.name} introduces core personal finance concepts for high school learners.`,
+        conceptualUnderstanding:
+          'Personal finance choices compound over time; informed, values-aligned decisions improve long-term outcomes.',
+        commonMisconceptions: [
+          'Financial literacy is only relevant in adulthood',
+          'Higher income alone guarantees financial stability',
+          'Small money decisions do not meaningfully affect long-term goals',
+        ],
+        realWorldConnections: [
+          'Managing paycheck-to-paycheck decisions',
+          'Comparing financial products and contracts',
+          'Planning for education, housing, and future goals',
+        ],
+        estimatedDuration: 50,
+        fiveRsAlignment: finlitTopic.fiveRsAlignment ?? null,
+      },
+    });
+
+    for (const [index, objective] of finlitTopic.learningObjectives.entries()) {
+      await prisma.learningObjective.upsert({
+        where: { id: `obj-${finlitTopic.key}-${index + 1}` },
+        update: {
+          description: objective,
+          topicId,
+          bloomsLevel: 'APPLY',
+        },
+        create: {
+          id: `obj-${finlitTopic.key}-${index + 1}`,
+          topicId,
+          description: objective,
+          bloomsLevel: 'APPLY',
+        },
+      });
+    }
+
+    console.log(`✅ Financial literacy topic created: ${finlitTopic.name}`);
+  }
+
   // ═══════════════════════════════════════════════════════════════
   // 8. CREATE LEARNING OBJECTIVES
   // ═══════════════════════════════════════════════════════════════

--- a/src/components/curriculum/curriculum-filters.tsx
+++ b/src/components/curriculum/curriculum-filters.tsx
@@ -18,6 +18,7 @@ const SUBJECT_LABELS = {
   MATH: 'Math',
   SCIENCE: 'Science',
   LANGUAGE_ARTS: 'Language Arts',
+  FINANCIAL_LITERACY: 'Financial Literacy',
 } as const;
 
 const FRAMEWORK_LABELS = {
@@ -106,7 +107,7 @@ export function CurriculumFilters({
           Grade Level
         </label>
         <div className="space-y-2">
-          {[6, 7, 8].map((grade) => (
+          {[6, 7, 8, 9, 10, 11, 12].map((grade) => (
             <label key={grade} className="flex items-center gap-2 cursor-pointer">
               <input
                 type="checkbox"


### PR DESCRIPTION
### Motivation
- Add a high-school Financial Literacy curriculum (Ch. I–XII) to the database so topics are available in the topic browser. 
- Ensure seeding is idempotent so re-running seeds does not create duplicates. 
- Surface FINANCIAL_LITERACY in the UI filters and store optional FiveR alignment metadata on topics.

### Description
- Extended the Prisma schema to add `FINANCIAL_LITERACY` to the `Subject` enum and added an optional `fiveRsAlignment` `Json?` field on `Topic` to hold chapter-level alignment metadata (`prisma/schema.prisma`).
- Added an idempotent seeding block to `prisma/seed.ts` that upserts 12 FINLIT topics (Ch. I–XII) with deterministic `topic-<key>` ids, each set to `subject: 'FINANCIAL_LITERACY'`, `gradeLevel: [9,10,11,12]`, `key`, `name`, `learningObjectives[]`, and optional `fiveRsAlignment`; each topic's learning objectives are upserted with deterministic `obj-<key>-<n>` ids to prevent duplicates.
- Updated the curriculum filters UI (`src/components/curriculum/curriculum-filters.tsx`) to expose a `Financial Literacy` subject label and to include grade levels 9–12 so seeded FINLIT topics are discoverable in the topic browser.

### Testing
- Verified there are 12 FINLIT chapter entries in the seed file using `rg` (count = 12); this check succeeded.
- Attempted schema deployment and seeding: `npx prisma db push` and `npx prisma db seed` were attempted but failed due to environment/npm registry restrictions (npm returned `403 Forbidden`), so the DB migration/seed could not be executed here.
- Attempted to load the running app and capture a Playwright screenshot of `/curriculum`, but the local app server was not running (`ERR_EMPTY_RESPONSE`), so UI verification could not be completed here.
- Changes were committed: added `prisma/schema.prisma`, `prisma/seed.ts`, and `src/components/curriculum/curriculum-filters.tsx` with the described updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f068a258832aa3b2f2e977ae4c5f)