### PR TITLE
Add Financial Literacy entry to student navigation (grade 9+)

### DIFF
--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { featureFlags } from '../feature-flags';
 import { phaseOrder, phaseTransitions } from '../five-rs';
-import { studentNavItems, educatorNavItems, parentNavItems, adminNavItems } from '../navigation';
+import { studentNavItems, getStudentNavItems, educatorNavItems, parentNavItems, adminNavItems } from '../navigation';
 import { pricingPlans } from '../pricing';
 import { siteConfig } from '../site';
 import { gradeSubjectMap } from '../subjects';
@@ -73,8 +73,19 @@ describe('phaseTransitions', () => {
 });
 
 describe('navigation', () => {
-  it('student nav has 5 items', () => {
-    expect(studentNavItems).toHaveLength(5);
+  it('student nav has 7 items total including grade-gated items', () => {
+    expect(studentNavItems).toHaveLength(7);
+  });
+
+
+  it('hides Financial Literacy for grades below 9', () => {
+    const labels = getStudentNavItems(8).map((i) => i.label);
+    expect(labels).not.toContain('Financial Literacy');
+  });
+
+  it('shows Financial Literacy for grade 9 and above', () => {
+    const labels = getStudentNavItems(9).map((i) => i.label);
+    expect(labels).toContain('Financial Literacy');
   });
 
   it('student nav includes Learn and Calm Corner', () => {

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,11 +1,36 @@
-export const studentNavItems = [
+export type NavItem = {
+  label: string;
+  href: string;
+  icon: string;
+  minGradeLevel?: number;
+};
+
+export const studentNavItems: readonly NavItem[] = [
   { label: 'Learn', href: '/learn', icon: 'book-open' },
+  {
+    label: 'Financial Literacy',
+    href: '/learn?subject=FINANCIAL_LITERACY',
+    icon: 'book-open',
+    minGradeLevel: 9,
+  },
   { label: 'Browse Curriculum', href: '/curriculum', icon: 'library' },
   { label: 'Calm Corner', href: '/regulate', icon: 'heart' },
   { label: 'My Progress', href: '/progress', icon: 'bar-chart' },
   { label: 'Community', href: '/community', icon: 'users' },
   { label: 'Settings', href: '/settings', icon: 'settings' },
 ] as const;
+
+export function getStudentNavItems(gradeLevel?: number): readonly NavItem[] {
+  return studentNavItems.filter((item) => {
+    if (item.minGradeLevel === undefined) {
+      return true;
+    }
+    if (typeof gradeLevel !== 'number') {
+      return false;
+    }
+    return gradeLevel >= item.minGradeLevel;
+  });
+}
 
 export const educatorNavItems = [
   { label: 'Students', href: '/educator/students', icon: 'users' },


### PR DESCRIPTION
### Motivation
- Expose a new Financial Literacy learning path from the student sidebar and route it to a subject-filtered learn view (`/learn?subject=FINANCIAL_LITERACY`).
- Ensure the entry is only shown to appropriate learners by enforcing a grade threshold (Grade 9+).

### Description
- Added a `NavItem` type and extended `studentNavItems` with a `Financial Literacy` item pointing to `/learn?subject=FINANCIAL_LITERACY` and metadata `minGradeLevel: 9` in `src/config/navigation.ts`.
- Implemented `getStudentNavItems(gradeLevel?)` to return student nav entries filtered by the optional `minGradeLevel` constraint.
- Updated `src/config/__tests__/config.test.ts` to import `getStudentNavItems`, adjust the expected student nav length, and add assertions that `Financial Literacy` is hidden for grade 8 and visible for grade 9+.

### Testing
- Updated unit tests in `src/config/__tests__/config.test.ts` to cover the new nav item and grade-gating behavior, but the test assertions were added and not yet verified by a successful run.
- Attempted to run `npx vitest run src/config/__tests__/config.test.ts`, which failed due to registry/security restrictions (npm returned `403 Forbidden`).
- Attempted to run `npm run test -- src/config/__tests__/config.test.ts`, which failed in this environment because `vitest` was not available; automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f0819e7c832ab77ad2e75b9eb986)