### PR TITLE
Add Clerk-based Playwright authentication setup for E2E coverage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,7 +68,11 @@ jobs:
         run: npx playwright install --with-deps
       
       - name: Run E2E tests
-        run: npm run test:e2e
+        run: |
+          npm run build
+          npm run start &
+          npx wait-on http://localhost:3000
+          npm run test:e2e
       
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,38 +13,46 @@ export default defineConfig({
     ['junit', { outputFile: 'test-results/junit.xml' }],
   ],
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL: process.env.NEXT_PUBLIC_APP_URL || process.env.BASE_URL || 'http://localhost:3000',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },
   projects: [
     {
+      name: 'setup',
+      testMatch: /.*setup\.ts/,
+    },
+    {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
     },
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
+      dependencies: ['setup'],
     },
     {
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
+      dependencies: ['setup'],
     },
     {
       name: 'mobile',
       use: { ...devices['iPhone 13'] },
+      dependencies: ['setup'],
     },
     {
       name: 'a11y-chromium',
       testMatch: /.*a11y.*\.spec\.ts/,
-      use: { 
+      use: {
         ...devices['Desktop Chrome'],
-        // Enable accessibility testing features
         contextOptions: {
           reducedMotion: 'reduce',
         },
       },
+      dependencies: ['setup'],
     },
   ],
   webServer: {

--- a/tests/e2e/setup.ts
+++ b/tests/e2e/setup.ts
@@ -1,0 +1,6 @@
+import { test as setup } from '@playwright/test';
+import { setupTestUsers } from '../helpers/auth';
+
+setup('setup test users', async () => {
+  await setupTestUsers();
+});

--- a/tests/e2e/student-chat.spec.ts
+++ b/tests/e2e/student-chat.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { loginAs, logout } from '../helpers/auth';
+
+test.describe('Student Chat Flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'STUDENT');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await logout(page);
+  });
+
+  test('should start a new tutoring session', async ({ page }) => {
+    await page.goto('/learn');
+
+    await expect(page.locator('[data-testid="phase-selector"]')).toBeVisible();
+
+    await page.click('[data-testid="phase-root"]');
+
+    await page.fill('[data-testid="chat-input"]', 'I need help with fractions');
+    await page.click('[data-testid="send-message"]');
+
+    await expect(page.locator('[data-testid="assistant-message"]')).toBeVisible();
+
+    const sessionTitle = await page.locator('[data-testid="session-title"]').textContent();
+    expect(sessionTitle).toBeTruthy();
+  });
+
+  test('should switch to Calm Corner when dysregulated', async ({ page }) => {
+    await page.goto('/learn');
+
+    await page.click('[data-testid="calm-corner-trigger"]');
+
+    await expect(page.locator('[data-testid="calm-corner-modal"]')).toBeVisible();
+
+    await page.click('[data-testid="breathing-exercise"]');
+
+    await page.waitForSelector('[data-testid="exercise-complete"]', { timeout: 10000 });
+
+    await page.click('[data-testid="return-to-chat"]');
+    await expect(page.locator('[data-testid="chat-input"]')).toBeVisible();
+  });
+});

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -1,0 +1,114 @@
+import { Page } from '@playwright/test';
+import { clerkClient } from '@clerk/nextjs/server';
+
+export type UserRole = 'STUDENT' | 'EDUCATOR' | 'PARENT' | 'SCHOOL_ADMIN';
+
+interface TestUser {
+  clerkUserId: string;
+  email: string;
+  password: string;
+  role: UserRole;
+}
+
+export const TEST_USERS: Record<UserRole, TestUser> = {
+  STUDENT: {
+    clerkUserId: '',
+    email: 'student.test@rootwork.edu',
+    password: 'Test123!@#',
+    role: 'STUDENT',
+  },
+  EDUCATOR: {
+    clerkUserId: '',
+    email: 'educator.test@rootwork.edu',
+    password: 'Test123!@#',
+    role: 'EDUCATOR',
+  },
+  PARENT: {
+    clerkUserId: '',
+    email: 'parent.test@rootwork.edu',
+    password: 'Test123!@#',
+    role: 'PARENT',
+  },
+  SCHOOL_ADMIN: {
+    clerkUserId: '',
+    email: 'admin.test@rootwork.edu',
+    password: 'Test123!@#',
+    role: 'SCHOOL_ADMIN',
+  },
+};
+
+export async function setupTestUsers() {
+  const client = await clerkClient();
+
+  for (const [role, userData] of Object.entries(TEST_USERS)) {
+    try {
+      const existingUsers = await client.users.getUserList({
+        emailAddress: [userData.email],
+      });
+
+      const existingUser = existingUsers.data[0];
+      if (existingUser) {
+        TEST_USERS[role as UserRole].clerkUserId = existingUser.id;
+        console.log(`Test user exists: ${userData.email}`);
+        continue;
+      }
+
+      const user = await client.users.createUser({
+        emailAddress: [userData.email],
+        password: userData.password,
+        firstName: role,
+        lastName: 'Test',
+        publicMetadata: {
+          role: userData.role,
+          tenantId: process.env.E2E_TEST_TENANT_ID ?? 'test-tenant-id',
+        },
+      });
+
+      TEST_USERS[role as UserRole].clerkUserId = user.id;
+      console.log(`Created test user: ${userData.email}`);
+    } catch (error) {
+      console.error(`Error creating test user ${userData.email}:`, error);
+    }
+  }
+}
+
+export async function loginAs(page: Page, role: UserRole) {
+  const user = TEST_USERS[role];
+
+  await page.goto('/sign-in');
+  await page.fill('input[name="identifier"]', user.email);
+  await page.click('button[type="submit"]');
+
+  await page.waitForSelector('input[name="password"]');
+  await page.fill('input[name="password"]', user.password);
+  await page.click('button[type="submit"]');
+
+  await page.waitForURL(/\/(dashboard|learn|educator|parent)/);
+}
+
+export async function getSessionToken(role: UserRole): Promise<string> {
+  const client = await clerkClient();
+  const user = TEST_USERS[role];
+
+  if (!user.clerkUserId) {
+    throw new Error(`Clerk user ID for ${role} is not set. Run setupTestUsers first.`);
+  }
+
+  const sessions = await client.sessions.getSessionList({
+    userId: user.clerkUserId,
+  });
+
+  const session = sessions.data[0];
+  if (!session) {
+    throw new Error(`No active sessions for ${role}`);
+  }
+
+  return session.id;
+}
+
+export async function logout(page: Page) {
+  await page.click('[data-testid="user-menu"]');
+  await page.click('[data-testid="sign-out"]');
+  await page.waitForURL('/');
+}
+


### PR DESCRIPTION
### Motivation
- Many E2E tests were skipped because there was no reliable way to authenticate test users in Playwright. 
- Provide a concrete Clerk-backed auth flow so test suites can provision users, log in in-browser, and obtain session tokens for API tests.

### Description
- Add `tests/helpers/auth.ts` which defines `TEST_USERS`, and provides `setupTestUsers()`, `loginAs()`, `logout()`, and `getSessionToken()` helpers using Clerk. 
- Add a Playwright setup test at `tests/e2e/setup.ts` that runs `setupTestUsers()` before other browser projects. 
- Update `playwright.config.ts` to add a `setup` project (`testMatch: /.*setup\.ts/`) and make browser and a11y projects depend on it. 
- Add an example authenticated E2E suite `tests/e2e/student-chat.spec.ts` that demonstrates `loginAs(page, 'STUDENT')` and `logout()` flows. 
- Update `.github/workflows/e2e-tests.yml` to build, start, and wait for the app prior to running Playwright in CI so tests run against a running server.

### Testing
- Attempted to list Playwright setup tests locally with `npx playwright test --list --project=setup`, but this failed due to an environment `npm` registry access error (`403 Forbidden`) when fetching Playwright, so Playwright test execution could not be validated locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1dc0da68832a95b9ac5b0cda3e3c)