### PR TITLE
Harden Stripe webhook signature verification and error handling

### DIFF
--- a/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -23,7 +23,7 @@ describe('POST /api/stripe/webhook', () => {
     process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test';
   });
 
-  it('returns 400 when signature or secret is missing', async () => {
+  it('returns 400 when signature is missing', async () => {
     const { POST } = await import('../route');
     delete process.env.STRIPE_WEBHOOK_SECRET;
 
@@ -35,7 +35,23 @@ describe('POST /api/stripe/webhook', () => {
     const response = await POST(request);
 
     expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({ error: 'Webhook signature verification failed.' });
+    await expect(response.json()).resolves.toEqual({ error: 'Missing signature.' });
+  });
+
+  it('returns 500 when webhook secret is missing', async () => {
+    const { POST } = await import('../route');
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+
+    const request = new Request('http://localhost/api/stripe/webhook', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'sig_123' },
+      body: '{}',
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: 'Webhook not configured.' });
   });
 
   it('syncs tenant after checkout session completion with a subscription id', async () => {
@@ -80,7 +96,7 @@ describe('POST /api/stripe/webhook', () => {
     expect(mockHandleSubscriptionCanceled).toHaveBeenCalledWith(deletedSubscription);
   });
 
-  it('returns 400 when Stripe event parsing fails', async () => {
+  it('returns 401 when Stripe signature verification fails', async () => {
     const { POST } = await import('../route');
     mockConstructEvent.mockImplementation(() => {
       throw new Error('Bad signature');
@@ -94,7 +110,7 @@ describe('POST /api/stripe/webhook', () => {
 
     const response = await POST(request);
 
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({ error: 'Invalid webhook payload.' });
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid signature.' });
   });
 });

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import Stripe from 'stripe';
 import { handleSubscriptionCanceled, syncTenantFromSubscription } from '@/lib/billing';
 import { stripe } from '@/lib/stripe';
 
@@ -6,15 +7,28 @@ export async function POST(request: Request) {
   const signature = request.headers.get('stripe-signature');
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
-  if (!signature || !webhookSecret) {
-    return NextResponse.json({ error: 'Webhook signature verification failed.' }, { status: 400 });
+  if (!signature) {
+    console.error('Missing Stripe signature header.');
+    return NextResponse.json({ error: 'Missing signature.' }, { status: 400 });
+  }
+
+  if (!webhookSecret) {
+    console.error('STRIPE_WEBHOOK_SECRET is not configured.');
+    return NextResponse.json({ error: 'Webhook not configured.' }, { status: 500 });
   }
 
   const payload = await request.text();
 
-  try {
-    const event = stripe.webhooks.constructEvent(payload, signature, webhookSecret);
+  let event: Stripe.Event;
 
+  try {
+    event = stripe.webhooks.constructEvent(payload, signature, webhookSecret);
+  } catch (error) {
+    console.error('Stripe webhook signature verification failed.', error);
+    return NextResponse.json({ error: 'Invalid signature.' }, { status: 401 });
+  }
+
+  try {
     if (event.type === 'checkout.session.completed') {
       const session = event.data.object;
       if (session.subscription && typeof session.subscription === 'string') {
@@ -32,7 +46,8 @@ export async function POST(request: Request) {
     }
 
     return NextResponse.json({ received: true });
-  } catch {
-    return NextResponse.json({ error: 'Invalid webhook payload.' }, { status: 400 });
+  } catch (error) {
+    console.error('Stripe webhook processing failed.', error);
+    return NextResponse.json({ error: 'Webhook processing failed.' }, { status: 500 });
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure Stripe webhooks are cryptographically verified before any business logic runs to reduce fraud risk.
- Distinguish failure modes (missing signature, missing secret config, invalid signature) with explicit HTTP statuses for clearer alerts and monitoring.
- Improve server-side observability by logging signature verification and processing errors.

### Description

- Split initial validation into two checks so a missing `stripe-signature` returns `400` and a missing `STRIPE_WEBHOOK_SECRET` returns `500` and logs the condition, in `src/app/api/stripe/webhook/route.ts`.
- Verify the raw payload with `stripe.webhooks.constructEvent` inside a `try/catch` and return `401` on signature verification failure, while logging the error.
- Surround event handling with a `try/catch` that logs downstream processing errors and returns `500` on failures instead of a generic `400`.
- Add `import Stripe from 'stripe'` and declare `let event: Stripe.Event;` and update unit tests in `src/app/api/stripe/webhook/__tests__/route.test.ts` to cover the new branches (missing signature, missing secret, invalid signature) and update expected status codes and response messages.

### Testing

- Updated unit tests at `src/app/api/stripe/webhook/__tests__/route.test.ts` to reflect new behavior and added a test for missing webhook secret; tests were committed but not executed successfully in this environment.
- Attempted `npm test -- src/app/api/stripe/webhook/__tests__/route.test.ts`, which failed because the `vitest` binary was not available (`vitest: not found`).
- Attempted `npx vitest run src/app/api/stripe/webhook/__tests__/route.test.ts`, which failed due to registry access restrictions (`403 Forbidden`) preventing `vitest` installation and test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1e7debd8832ab3944caaa92872f8)