### PR TITLE
Fix Next.js 15 route param typing and restore audit logging export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
-  serverComponentsExternalPackages: [
+  serverExternalPackages: [
     'dd-trace',
     '@datadog/libdatadog',
     '@datadog/openfeature-node-server',

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -53,3 +53,26 @@ export async function appendImmutableAuditLog(input: AuditWriteInput) {
     },
   });
 }
+
+
+export type CreateAuditLogInput = {
+  tenantId: string;
+  userId: string;
+  action: string;
+  resource: string;
+  resourceId?: string | null;
+  details?: unknown;
+  ipAddress?: string | null;
+};
+
+export async function createAuditLog(input: CreateAuditLogInput) {
+  return appendImmutableAuditLog({
+    tenantId: input.tenantId,
+    userId: input.userId,
+    action: input.action,
+    resource: input.resource,
+    resourceId: input.resourceId,
+    metadata: input.details,
+    ipAddress: input.ipAddress,
+  });
+}

--- a/src/lib/middleware/rbac-middleware.ts
+++ b/src/lib/middleware/rbac-middleware.ts
@@ -30,14 +30,24 @@ export interface AuthenticatedUser {
 
 export type RouteHandler = (
   req: NextRequest,
-  context?: { params: Record<string, string> }
+  context?: { params: Promise<Record<string, string>> }
 ) => Promise<Response>;
 
 export type AuthenticatedRouteHandler = (
   req: NextRequest,
   user: AuthenticatedUser,
-  context?: { params: Record<string, string> }
+  context?: { params: Promise<Record<string, string>> }
 ) => Promise<Response>;
+
+async function resolveParams(context?: {
+  params: Promise<Record<string, string>>;
+}): Promise<Record<string, string> | undefined> {
+  if (!context?.params) {
+    return undefined;
+  }
+
+  return context.params;
+}
 
 // ============================================================================
 // Core Middleware Functions
@@ -70,7 +80,7 @@ async function getAuthenticatedUser(): Promise<AuthenticatedUser> {
  * Basic authentication middleware - ensures user is logged in
  */
 export function withAuth(handler: AuthenticatedRouteHandler): RouteHandler {
-  return async (req: NextRequest, context?: { params: Record<string, string> }) => {
+  return async (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => {
     try {
       const user = await getAuthenticatedUser();
       return await handler(req, user, context);
@@ -85,7 +95,7 @@ export function withAuth(handler: AuthenticatedRouteHandler): RouteHandler {
  * Permission-based middleware - ensures user has required permission
  */
 export function withPermission(permission: PermissionKey, handler: AuthenticatedRouteHandler): RouteHandler {
-  return async (req: NextRequest, context?: { params: Record<string, string> }) => {
+  return async (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => {
     try {
       const user = await getAuthenticatedUser();
 
@@ -109,7 +119,7 @@ export function withPermission(permission: PermissionKey, handler: Authenticated
  * Role-based middleware - ensures user has one of the required roles
  */
 export function withRole(roles: UserRole[], handler: AuthenticatedRouteHandler): RouteHandler {
-  return async (req: NextRequest, context?: { params: Record<string, string> }) => {
+  return async (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => {
     try {
       const user = await getAuthenticatedUser();
 
@@ -138,7 +148,7 @@ export function withRole(roles: UserRole[], handler: AuthenticatedRouteHandler):
  * Only PLATFORM_ADMIN can access these routes
  */
 export function withGlobalCurriculumAccess(handler: AuthenticatedRouteHandler): RouteHandler {
-  return async (req: NextRequest, context?: { params: Record<string, string> }) => {
+  return async (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => {
     try {
       const user = await getAuthenticatedUser();
 
@@ -158,7 +168,7 @@ export function withGlobalCurriculumAccess(handler: AuthenticatedRouteHandler): 
  * SCHOOL_ADMIN, DISTRICT_ADMIN, PLATFORM_ADMIN can access
  */
 export function withSchoolCurriculumAccess(handler: AuthenticatedRouteHandler): RouteHandler {
-  return async (req: NextRequest, context?: { params: Record<string, string> }) => {
+  return async (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => {
     try {
       const user = await getAuthenticatedUser();
 
@@ -170,7 +180,8 @@ export function withSchoolCurriculumAccess(handler: AuthenticatedRouteHandler): 
       }
 
       // If school ID is provided in context, validate school access
-      const schoolId = context?.params?.schoolId;
+      const params = await resolveParams(context);
+      const schoolId = params?.schoolId;
       if (schoolId && user.role === 'SCHOOL_ADMIN') {
         assertSchoolAccess(user.role, user.schoolId, schoolId);
       }
@@ -190,7 +201,7 @@ export function withSchoolCurriculumAccess(handler: AuthenticatedRouteHandler): 
  * SCHOOL_ADMIN, DISTRICT_ADMIN, PLATFORM_ADMIN can access all classrooms in their scope
  */
 export function withClassroomAccess(handler: AuthenticatedRouteHandler): RouteHandler {
-  return async (req: NextRequest, context?: { params: Record<string, string> }) => {
+  return async (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => {
     try {
       const user = await getAuthenticatedUser();
 
@@ -202,7 +213,8 @@ export function withClassroomAccess(handler: AuthenticatedRouteHandler): RouteHa
       }
 
       // If class ID is provided in context, validate classroom access
-      const classId = context?.params?.classId || context?.params?.id;
+      const params = await resolveParams(context);
+      const classId = params?.classId || params?.id;
       if (classId) {
         await assertCanManageClassroomLearningPath(user.id, user.role, classId);
       }
@@ -225,7 +237,7 @@ export function withClassroomAccess(handler: AuthenticatedRouteHandler): RouteHa
  * Prevents cross-tenant data access
  */
 export function withTenantScope(handler: AuthenticatedRouteHandler): RouteHandler {
-  return async (req: NextRequest, context?: { params: Record<string, string> }) => {
+  return async (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => {
     try {
       const user = await getAuthenticatedUser();
 


### PR DESCRIPTION
### Motivation
- Next.js 15 route handlers pass `params` as an async value, so middleware and wrapped handlers must accept and await `context.params` to avoid runtime/typing errors.
- The data-retention code imports `createAuditLog` but `src/lib/audit.ts` did not export a compatible helper, causing unresolved import/use sites.
- `next.config.js` used the deprecated `serverComponentsExternalPackages` option which should be updated for Next.js 15 compatibility.

### Description
- Updated RBAC middleware route handler typings to accept `context.params` as a `Promise<Record<string,string>>` so middleware-wrapped handlers align with Next.js 15 behavior (`src/lib/middleware/rbac-middleware.ts`).
- Added a small `resolveParams` helper and updated school/class access checks to `await` route params before reading `schoolId`/`classId` to avoid synchronous access of unresolved params (`src/lib/middleware/rbac-middleware.ts`).
- Added a compatibility wrapper `createAuditLog` that delegates to `appendImmutableAuditLog` to restore the expected audit API used by compliance/data-retention code (`src/lib/audit.ts`).
- Replaced deprecated `serverComponentsExternalPackages` with `serverExternalPackages` in `next.config.js` for Next.js 15 compatibility (`next.config.js`).

### Testing
- Ran TypeScript check with `npx tsc --noEmit`, which failed due to pre-existing, unrelated TypeScript syntax errors in other files (`src/app/api/ingest/route.ts`, `src/app/api/irt/...`, and `src/lib/curriculum/parser.ts`), so type-checking of these changes could not be fully validated end-to-end.
- No other automated tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1f138c40832aa5fc50dbf4b1ab86)