### PR TITLE
Fix unmatched route handler closures in ingest and IRT API endpoints

### DIFF
--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -46,6 +46,6 @@ export async function POST(req: NextRequest) {
     await db.ingestLog.update({ where: { id: log.id }, data: { status: 'FAILURE', errorMessage, durationMs: Date.now() - startTime } });
     return NextResponse.json({ error: 'Ingestion failed', message: errorMessage, logId: log.id }, { status: 500 });
   }
-});
+}
 
 export async function GET() { return NextResponse.json({ status: 'ok' }); }

--- a/src/app/api/irt/ability/route.ts
+++ b/src/app/api/irt/ability/route.ts
@@ -5,32 +5,25 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { withApiHandler } from '@/lib/api-handler';
-import { ValidationError } from '@/lib/api-errors';
 import { getStudentAbility } from '@/lib/irt';
 
 export async function GET(request: NextRequest) {
-  try {
-    const searchParams = request.nextUrl.searchParams;
-    const studentId = searchParams.get('studentId');
-    const subject = searchParams.get('subject') as 'MATH' | 'SCIENCE' | 'LANGUAGE_ARTS' | 'FINANCIAL_LITERACY';
+  const searchParams = request.nextUrl.searchParams;
+  const studentId = searchParams.get('studentId');
+  const subject = searchParams.get('subject') as 'MATH' | 'SCIENCE' | 'LANGUAGE_ARTS' | 'FINANCIAL_LITERACY';
 
-    if (!studentId || !subject) {
-      return NextResponse.json(
-        { error: 'Missing required parameters: studentId and subject' },
-        { status: 400 }
-      );
-    }
+  if (!studentId || !subject) {
+    return NextResponse.json(
+      { error: 'Missing required parameters: studentId and subject' },
+      { status: 400 }
+    );
+  }
 
-    if (!['MATH', 'SCIENCE', 'LANGUAGE_ARTS', 'FINANCIAL_LITERACY'].includes(subject)) {
-      return NextResponse.json(
-        { error: 'Invalid subject. Must be MATH, SCIENCE, or LANGUAGE_ARTS' },
-        { status: 400 }
-      );
-    }
-
-  if (!['MATH', 'SCIENCE', 'LANGUAGE_ARTS'].includes(subject)) {
-    throw new ValidationError('Invalid subject. Must be MATH, SCIENCE, or LANGUAGE_ARTS');
+  if (!['MATH', 'SCIENCE', 'LANGUAGE_ARTS', 'FINANCIAL_LITERACY'].includes(subject)) {
+    return NextResponse.json(
+      { error: 'Invalid subject. Must be MATH, SCIENCE, LANGUAGE_ARTS, or FINANCIAL_LITERACY' },
+      { status: 400 }
+    );
   }
 
   const ability = await getStudentAbility(studentId, subject);
@@ -47,4 +40,4 @@ export async function GET(request: NextRequest) {
   }
 
   return NextResponse.json(ability);
-});
+}

--- a/src/app/api/irt/next-item/route.ts
+++ b/src/app/api/irt/next-item/route.ts
@@ -12,55 +12,40 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { withApiHandler } from '@/lib/api-handler';
-import { ValidationError, NotFoundError } from '@/lib/api-errors';
+import { NotFoundError } from '@/lib/api-errors';
 import { selectNextItem, getStudentAbility } from '@/lib/irt';
 import type { Subject, BloomsLevel } from '@prisma/client';
 
 export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const {
-      studentId,
-      subject,
-      currentTheta,
-      excludeAssessmentIds,
-      bloomsLevelDistribution,
-    } = body;
+  const body = await request.json();
+  const {
+    studentId,
+    subject,
+    currentTheta,
+    excludeAssessmentIds,
+    bloomsLevelDistribution,
+  } = body;
 
-    if (!studentId || !subject) {
-      return NextResponse.json(
-        { error: 'Missing required parameters: studentId and subject' },
-        { status: 400 }
-      );
-    }
-
-    if (!['MATH', 'SCIENCE', 'LANGUAGE_ARTS', 'FINANCIAL_LITERACY'].includes(subject)) {
-      return NextResponse.json(
-        { error: 'Invalid subject. Must be MATH, SCIENCE, or LANGUAGE_ARTS' },
-        { status: 400 }
-      );
-    }
-
-    // Get student's current theta if not provided
-    let theta = currentTheta;
-    if (theta === undefined) {
-      const ability = await getStudentAbility(studentId, subject as Subject);
-      theta = ability?.theta ?? 0;
-    }
-
-  if (!['MATH', 'SCIENCE', 'LANGUAGE_ARTS'].includes(subject)) {
-    throw new ValidationError('Invalid subject. Must be MATH, SCIENCE, or LANGUAGE_ARTS');
+  if (!studentId || !subject) {
+    return NextResponse.json(
+      { error: 'Missing required parameters: studentId and subject' },
+      { status: 400 }
+    );
   }
 
-  // Get student's current theta if not provided
+  if (!['MATH', 'SCIENCE', 'LANGUAGE_ARTS', 'FINANCIAL_LITERACY'].includes(subject)) {
+    return NextResponse.json(
+      { error: 'Invalid subject. Must be MATH, SCIENCE, LANGUAGE_ARTS, or FINANCIAL_LITERACY' },
+      { status: 400 }
+    );
+  }
+
   let theta = currentTheta;
   if (theta === undefined) {
     const ability = await getStudentAbility(studentId, subject as Subject);
     theta = ability?.theta ?? 0;
   }
 
-  // Select next item
   const selectedItem = await selectNextItem({
     studentId,
     subject: subject as Subject,
@@ -74,4 +59,4 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json(selectedItem);
-});
+}


### PR DESCRIPTION
### Motivation
- Correct Next.js App Router handler syntax in several API routes to remove dangling `});` closures and ensure exported functions close properly.
- Remove duplicated/invalid validation flow and unused imports that were leftover from Express-style or wrapped handlers to avoid runtime/parsing errors.

### Description
- Replace the incorrect `});` terminator with `}` in `src/app/api/ingest/route.ts` so the exported `POST` handler is a properly-closed function export.
- Rewrite `src/app/api/irt/ability/route.ts` to ensure the exported `GET` handler has a proper body closure and simplified subject validation, removing unused imports like `withApiHandler` and `ValidationError`.
- Rewrite `src/app/api/irt/next-item/route.ts` to ensure the exported `POST` handler closes correctly, remove duplicated validation/theta-derivation logic, and drop the unused `withApiHandler`/`ValidationError` imports.

### Testing
- Attempted to lint the modified files with `npm run lint -- --file src/app/api/ingest/route.ts --file src/app/api/irt/ability/route.ts --file src/app/api/irt/next-item/route.ts`, but the command failed because `next` is not available in this environment (`sh: 1: next: not found`).
- Verified file changes via `git diff`/file inspection and committed the fixes to the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a29d046e0832abf7a374d1b39c906)