### PR TITLE
Fix Parent seed payload to match Prisma schema

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -251,8 +251,7 @@ async function main() {
     update: {},
     create: {
       userId: parentUser.id,
-      relationshipType: 'PARENT',
-      communicationPreferences: {
+      communicationPrefs: {
         email: true,
         sms: false,
         weeklyReports: true,


### PR DESCRIPTION
### Motivation
- Ensure the parent seed data matches the `Parent` Prisma model by removing unsupported fields and using the correct field name so seeding does not fail at runtime.

### Description
- Updated `prisma/seed.ts` to remove the unsupported `relationshipType` property from the `prisma.parent.upsert(...).create` payload and renamed `communicationPreferences` to `communicationPrefs` to match the schema.

### Testing
- Ran `npm run db:generate` which failed in this environment with `sh: 1: prisma: not found`, so generation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a48eefd58832ab4da70df5239229f)