### PR TITLE
Fix seed script parent-student linkage to match schema

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -246,11 +246,14 @@ async function main() {
     },
   });
 
-  const parent = await prisma.parent.upsert({
+  await prisma.parent.upsert({
     where: { userId: parentUser.id },
-    update: {},
+    update: {
+      childrenIds: students.length > 0 ? [students[0].user.id] : [],
+    },
     create: {
       userId: parentUser.id,
+      childrenIds: students.length > 0 ? [students[0].user.id] : [],
       communicationPrefs: {
         email: true,
         sms: false,
@@ -258,26 +261,6 @@ async function main() {
       },
     },
   });
-
-  // Link parent to Alex Martinez (first student)
-  if (students.length > 0) {
-    await prisma.parentStudentRelationship.upsert({
-      where: {
-        parentId_studentId: {
-          parentId: parent.id,
-          studentId: students[0].student.id,
-        },
-      },
-      update: {},
-      create: {
-        tenantId: tenant.id,
-        parentId: parent.id,
-        studentId: students[0].student.id,
-        relationshipType: 'PARENT',
-        isPrimary: true,
-      },
-    });
-  }
 
   console.log(`✅ Parent created: ${parentUser.firstName} ${parentUser.lastName}`);
 


### PR DESCRIPTION
### Motivation

- The seed attempted to use a `ParentStudentRelationship` model that does not exist in the Prisma schema, causing runtime errors during seeding.
- The schema stores parent-child links on `Parent.childrenIds` (a `String[]`) so seeding must write IDs into that array rather than calling a non-existent junction model.

### Description

- Removed the invalid `prisma.parentStudentRelationship.upsert(...)` block from `prisma/seed.ts` to stop referencing a model that isn't defined in `schema.prisma`.
- Updated the parent `upsert` to set `childrenIds` in both `update` and `create` branches so the parent is linked to the first student at creation or update via `childrenIds`.
- The seed now uses the student `user` ID (`students[0].user.id`) when populating `childrenIds` to align with authorization checks that compare against `student.userId`.
- Changes are confined to `prisma/seed.ts` and bring seeding behavior in line with `model Parent { childrenIds String[] }` in `prisma/schema.prisma`.

### Testing

- Ran a repository search with `rg "parentStudentRelationship|ParentStudentRelationship" -n` to confirm there are no remaining references and the search returned no results (succeeded).
- Ran `npx prisma validate` to validate the Prisma setup but it failed due to external registry access returning `403 Forbidden` (environment/registry error, test failed).
- Attempted `./node_modules/.bin/prisma validate` to validate locally but the Prisma binary was not present in the environment (binary not found, test failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a4a648b58832a845c554530436f42)