### PR TITLE
Harden Prisma seed/schema alignment and prevent delegate mismatches

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "compliance:check": "node scripts/validate-compliance.mjs",
     "vercel-build": "prisma generate && next build",
     "ops:parallel": "node ./scripts/parallel-task-agents.mjs",
-    "ops:doctor": "node ./scripts/ops-doctor.mjs"
+    "ops:doctor": "node ./scripts/ops-doctor.mjs",
+    "db:seed:check": "node scripts/validate-seed-schema-sync.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.0",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -246,11 +246,14 @@ async function main() {
     },
   });
 
-  const parent = await prisma.parent.upsert({
+  await prisma.parent.upsert({
     where: { userId: parentUser.id },
-    update: {},
+    update: {
+      childrenIds: students.length > 0 ? [students[0].user.id] : [],
+    },
     create: {
       userId: parentUser.id,
+      childrenIds: students.length > 0 ? [students[0].user.id] : [],
       communicationPrefs: {
         email: true,
         sms: false,
@@ -258,26 +261,6 @@ async function main() {
       },
     },
   });
-
-  // Link parent to Alex Martinez (first student)
-  if (students.length > 0) {
-    await prisma.parentStudentRelationship.upsert({
-      where: {
-        parentId_studentId: {
-          parentId: parent.id,
-          studentId: students[0].student.id,
-        },
-      },
-      update: {},
-      create: {
-        tenantId: tenant.id,
-        parentId: parent.id,
-        studentId: students[0].student.id,
-        relationshipType: 'PARENT',
-        isPrimary: true,
-      },
-    });
-  }
 
   console.log(`✅ Parent created: ${parentUser.firstName} ${parentUser.lastName}`);
 

--- a/scripts/validate-seed-schema-sync.mjs
+++ b/scripts/validate-seed-schema-sync.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const schemaPath = path.join(repoRoot, 'prisma/schema.prisma');
+const seedPath = path.join(repoRoot, 'prisma/seed.ts');
+
+const schema = fs.readFileSync(schemaPath, 'utf8');
+const seed = fs.readFileSync(seedPath, 'utf8');
+
+const modelNames = [...schema.matchAll(/^model\s+(\w+)\s+\{/gm)].map((m) => m[1]);
+const delegates = new Set(modelNames.map((m) => m.charAt(0).toLowerCase() + m.slice(1)));
+
+const usedDelegates = [...seed.matchAll(/prisma\.(\w+)\./g)]
+  .map((m) => m[1])
+  .filter((name) => !name.startsWith('$'));
+
+const unknown = [...new Set(usedDelegates.filter((delegate) => !delegates.has(delegate)))];
+
+if (unknown.length > 0) {
+  console.error('❌ Seed schema sync check failed. Unknown Prisma delegates found:');
+  for (const name of unknown) {
+    console.error(`   - prisma.${name}`);
+  }
+  process.exit(1);
+}
+
+console.log('✅ Seed schema sync check passed. All Prisma delegates used in prisma/seed.ts exist in prisma/schema.prisma models.');


### PR DESCRIPTION
### Motivation
- The seed previously referenced a non-existent junction model for parent-student links which caused runtime failures during seeding and drift between `prisma/seed.ts` and `prisma/schema.prisma`.
- We need a fast-fail check to catch any future cases where `prisma/<delegate>` is used in the seed but the corresponding `model` is missing from the schema.
- Adding an easily runnable check makes it straightforward to validate seed/schema alignment in CI or locally before running the runtime seed.

### Description
- Updated `prisma/seed.ts` to stop referencing a non-existent junction model and instead populate `Parent.childrenIds` in both the `update` and `create` branches of the parent `upsert` so parent-child linkage matches the schema.
- Removed the old `prisma.parentStudentRelationship.upsert(...)` block and the unused `parent` variable to eliminate references to a model not present in `prisma/schema.prisma`.
- Added `scripts/validate-seed-schema-sync.mjs` which parses `prisma/schema.prisma` for model names and verifies every `prisma.<delegate>` used in `prisma/seed.ts` maps to an actual model delegate, and added an npm script `db:seed:check` to run this validation.

### Testing
- Ran `npm run db:seed:check` (which executes `node scripts/validate-seed-schema-sync.mjs`) and it passed, reporting that all used Prisma delegates exist in the schema (success).
- Executed a repository search `rg "parentStudentRelationship|ParentStudentRelationship" -n` to confirm there are no remaining references and it returned no results (success).
- Attempted `npm run db:seed` to run the full seed but it failed locally because the `tsx` binary was not found in the environment (failure unrelated to the seed/schema mismatch fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a4a648b58832a845c554530436f42)