### PR TITLE
fix(seed): type financial literacy topics with optional fiveRsAlignment

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -543,7 +543,14 @@ async function main() {
   // ═══════════════════════════════════════════════════════════════
   console.log('Creating financial literacy topics...');
 
-  const finlitTopics = [
+  type FinlitTopic = {
+    key: string;
+    name: string;
+    learningObjectives: string[];
+    fiveRsAlignment?: Record<string, string>;
+  };
+
+  const finlitTopics: FinlitTopic[] = [
     {
       key: 'finlit-ch-i-income-career-planning',
       name: 'Ch. I: Income and Career Planning',
@@ -647,7 +654,7 @@ async function main() {
       ],
       fiveRsAlignment: { ROOT: 'Values and priorities', RECONNECT: 'Action plan and accountability' },
     },
-  ] as const;
+  ];
 
   for (const finlitTopic of finlitTopics) {
     const topicId = `topic-${finlitTopic.key}`;


### PR DESCRIPTION
### Motivation

- Some entries in the `finlitTopics` seed array omit `fiveRsAlignment`, and accessing `finlitTopic.fiveRsAlignment` caused a TypeScript type error due to overly strict inference from `as const`.

### Description

- Introduced a `FinlitTopic` type in `prisma/seed.ts` with `fiveRsAlignment` marked optional to allow mixed objects. 
- Typed the `finlitTopics` array as `FinlitTopic[]` and removed the `as const` assertion that produced a narrow union. 
- Kept the existing runtime behavior of writing `fiveRsAlignment: finlitTopic.fiveRsAlignment ?? null` when upserting topics. 
- Modified file: `prisma/seed.ts`.

### Testing

- Ran `npm run db:seed:check` which executed the seed/schema sync validation and passed successfully. 
- Ran `npx tsc --noEmit prisma/seed.ts` which failed in this environment due to missing TypeScript lib/type declarations unrelated to the code change (project-level tsc configuration and node types not loaded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a7daa1988832aba032ff72fd9d772)