### PR TITLE
Add InternalServerError and BadRequestError alias to src/lib/api-errors.ts

### DIFF
--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -79,3 +79,13 @@ export class RateLimitError extends AppError {
     this.name = 'RateLimitError';
   }
 }
+
+export class InternalServerError extends AppError {
+  constructor(message = 'Internal server error', details?: unknown) {
+    super(message, 500, 'INTERNAL_ERROR', details);
+    this.name = 'InternalServerError';
+  }
+}
+
+// Alias for backward compatibility
+export const BadRequestError = ValidationError;


### PR DESCRIPTION
### Motivation
- Route files were importing `BadRequestError` and expected an `InternalServerError` export, causing import errors and breakage.  
- Provide a 500-level error class and a 400-level alias to maintain backward compatibility without changing many route files.

### Description
- Added `InternalServerError` class to `src/lib/api-errors.ts` that extends `AppError` with status `500` and code `INTERNAL_ERROR`.  
- Added `export const BadRequestError = ValidationError;` in `src/lib/api-errors.ts` to alias `ValidationError` for backward compatibility.  
- These exports resolve missing-import issues for existing route files and maintain the existing error shape.

### Testing
- Ran `npm run lint`, which failed in this environment because `next` is not available (`sh: 1: next: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8d42bdc0832abcd0e56f8a1ba559)