### PR TITLE
fix: use requireUser helper in chat route

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -79,10 +79,7 @@ function isPersonalTradeAdviceRequest(message: string): boolean {
 
 
 export async function POST(req: NextRequest) {
-  const { userId: clerkId } = auth();
-  if (!clerkId) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
-  }
+  const user = await requireUser(req);
 
   if (!user.student) {
     throw new NotFoundError('Student profile not found');


### PR DESCRIPTION
### Motivation
- Replace manual Clerk auth check with the shared `requireUser(req)` helper so authentication is centralized and the handler receives the full `user` object for downstream authorization and profile checks.

### Description
- Replaced the manual auth block in `src/app/api/chat/route.ts` with `const user = await requireUser(req);` and preserved existing `user` usage and student checks.

### Testing
- No automated tests were run for this small, targeted change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9c641f60832a92e7b516187c7f41)