### PR TITLE
fix: call requireUser() without args in chat POST route

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -79,7 +79,7 @@ function isPersonalTradeAdviceRequest(message: string): boolean {
 
 
 export async function POST(req: NextRequest) {
-  const user = await requireUser(req);
+  const user = await requireUser();
 
   if (!user.student) {
     throw new NotFoundError('Student profile not found');


### PR DESCRIPTION
### Motivation
- The `requireUser` helper reads the request from the server context and does not accept a `req` argument, so the callsite should be updated to match its API.

### Description
- Changed `requireUser(req)` to `requireUser()` in `src/app/api/chat/route.ts` within the `POST` handler.

### Testing
- No automated tests were run for this one-line change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9d9f85a8832a8aca7d922164f1e4)