### PR TITLE
Fix Prisma JSON compatibility for session regulationState updates

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -163,13 +163,13 @@ export async function POST(req: NextRequest) {
       where: { id: session.id },
       data: {
         currentPhase: nextPhase,
-        regulationState: {
+        regulationState: JSON.parse(JSON.stringify({
           level: newRegulationLevel,
           signals: regulationCheck.signals,
           interventionCount: (currentRegulationState?.interventionCount ?? 0) + (regulationCheck.severity === 'high' ? 1 : 0),
           sentiment,
           regulationPassed: nextFiveRState.regulationPassed,
-        },
+        })),
         metadata: {
           ...(session.metadata as Record<string, unknown> ?? {}),
           fiveRState: nextFiveRState,


### PR DESCRIPTION
### Motivation
- Prisma JSON fields require values with an index signature and proper JSON-serializable types, and the `regulationState` payload included a nested `sentiment` object that did not satisfy those constraints.

### Description
- Wrap the `regulationState` payload in `JSON.parse(JSON.stringify(...))` when updating the session in `src/app/api/chat/route.ts` so the object is JSON-serializable for Prisma.

### Testing
- Ran the lint script with `npm run lint`, which failed in this environment due to missing runtime tooling (`sh: 1: next: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa41317b4832ab445d9c9c23fab77)