### PR TITLE
Serialize session metadata for Prisma JSON compatibility in chat route

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -170,10 +170,10 @@ export async function POST(req: NextRequest) {
           sentiment,
           regulationPassed: nextFiveRState.regulationPassed,
         })),
-        metadata: {
+        metadata: JSON.parse(JSON.stringify({
           ...(session.metadata as Record<string, unknown> ?? {}),
           fiveRState: nextFiveRState,
-        },
+        })),
       },
     });
   }


### PR DESCRIPTION
### Motivation
- Prisma JSON fields require strictly JSON-serializable values, and the existing spread-based metadata merge could surface non-JSON-safe values.
- Ensure the merged `metadata` (including the `fiveRState` snapshot) is safe to persist to the database.

### Description
- Updated `src/app/api/chat/route.ts` to wrap the `metadata` payload in `JSON.parse(JSON.stringify({...}))` when calling `db.session.update`.
- The change mirrors the existing serialization applied to `regulationState` and ensures `fiveRState` is stored only with JSON-compatible data.
- This specifically replaces the previous direct object assignment that merged `session.metadata` with `fiveRState`.

### Testing
- Attempted to run the chat tests with `npm run -s test -- src/app/api/chat/__tests__/citations.test.ts --run`, but the run failed because `vitest` was not found on the PATH in the current environment. 
- No other automated tests were executed in this environment due to the missing test runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aaa11b1e0832ab5e9f6f7fb93227f)