### PR TITLE
Add Cloudflare challenges to Content Security Policy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -48,7 +48,7 @@ const nextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.clerk.io https://*.clerk.accounts.dev https://js.stripe.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.clerk.com https://images.unsplash.com; font-src 'self'; connect-src 'self' https://api.clerk.io https://*.clerk.accounts.dev https://api.stripe.com https://*.pinecone.io https://api.anthropic.com https://api.openai.com; frame-src https://js.stripe.com https://accounts.clerk.dev https://*.clerk.accounts.dev; object-src 'none'; base-uri 'self'; form-action 'self';",
+              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.clerk.io https://*.clerk.accounts.dev https://js.stripe.com https://challenges.cloudflare.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.clerk.com https://images.unsplash.com; font-src 'self'; connect-src 'self' https://api.clerk.io https://*.clerk.accounts.dev https://api.stripe.com https://*.pinecone.io https://api.anthropic.com https://api.openai.com https://challenges.cloudflare.com; frame-src https://js.stripe.com https://accounts.clerk.dev https://*.clerk.accounts.dev https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; form-action 'self';",
           },
         ],
       },


### PR DESCRIPTION
## Summary
Updated the Content Security Policy (CSP) header in `next.config.js` to allow resources from Cloudflare's challenge domain, enabling support for Cloudflare security features.

## Changes
- Added `https://challenges.cloudflare.com` to the `script-src` directive to allow Cloudflare challenge scripts
- Added `https://challenges.cloudflare.com` to the `connect-src` directive to allow API connections to Cloudflare challenges
- Added `https://challenges.cloudflare.com` to the `frame-src` directive to allow Cloudflare challenge frames

## Details
These CSP updates enable the application to work with Cloudflare's security and challenge features (such as bot management or DDoS protection), which require loading scripts and establishing connections to Cloudflare's challenge infrastructure.

https://claude.ai/code/session_01MMzJvMkqfF4oZtZXPukCCS