### PR TITLE
Add production DB migration workflow, load-test baseline CI, Clerk E2E secrets & ops runbook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,18 @@ jobs:
       - name: Pull Vercel Environment
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
+      - name: Apply production database migrations
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          if [ -z "${DATABASE_URL}" ]; then
+            echo "PRODUCTION_DATABASE_URL secret is not configured." >&2
+            exit 1
+          fi
+          npm ci
+          npx prisma generate
+          npx prisma migrate deploy
+
       - name: Build Project
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,8 +32,9 @@ jobs:
     
     env:
       DATABASE_URL: postgresql://rootwork:rootwork_e2e@localhost:5432/rootwork_test?schema=public
-      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_TEST || 'pk_test_placeholder' }}
-      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_TEST || 'sk_test_placeholder' }}
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_TEST }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_TEST }}
+      CLERK_TESTING_TOKEN: ${{ secrets.CLERK_TESTING_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || 'sk-ant-placeholder' }}
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY_TEST || 'sk_test_placeholder' }}
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY_TEST || 'pk_test_placeholder' }}
@@ -41,6 +42,14 @@ jobs:
       N8N_WEBHOOK_SECRET: test_webhook_secret
       NEXT_PUBLIC_APP_URL: http://localhost:3000
       BASE_URL: http://localhost:3000
+      E2E_CLERK_USER_STUDENT_EMAIL: ${{ secrets.E2E_CLERK_USER_STUDENT_EMAIL }}
+      E2E_CLERK_USER_STUDENT_PASSWORD: ${{ secrets.E2E_CLERK_USER_STUDENT_PASSWORD }}
+      E2E_CLERK_USER_EDUCATOR_EMAIL: ${{ secrets.E2E_CLERK_USER_EDUCATOR_EMAIL }}
+      E2E_CLERK_USER_EDUCATOR_PASSWORD: ${{ secrets.E2E_CLERK_USER_EDUCATOR_PASSWORD }}
+      E2E_CLERK_USER_PARENT_EMAIL: ${{ secrets.E2E_CLERK_USER_PARENT_EMAIL }}
+      E2E_CLERK_USER_PARENT_PASSWORD: ${{ secrets.E2E_CLERK_USER_PARENT_PASSWORD }}
+      E2E_CLERK_USER_ADMIN_EMAIL: ${{ secrets.E2E_CLERK_USER_ADMIN_EMAIL }}
+      E2E_CLERK_USER_ADMIN_PASSWORD: ${{ secrets.E2E_CLERK_USER_ADMIN_PASSWORD }}
     
     steps:
       - name: Checkout code

--- a/.github/workflows/load-test-baseline.yml
+++ b/.github/workflows/load-test-baseline.yml
@@ -1,0 +1,84 @@
+name: Load Test + SLO Baseline
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: rootwork_test
+          POSTGRES_USER: rootwork
+          POSTGRES_PASSWORD: rootwork_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U rootwork"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=5
+    env:
+      DATABASE_URL: postgresql://rootwork:rootwork_ci@localhost:5432/rootwork_test?schema=public
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_TEST || 'pk_test_placeholder' }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_TEST || 'sk_test_placeholder' }}
+      ANTHROPIC_API_KEY: sk-ant-placeholder
+      OPENAI_API_KEY: sk-openai-placeholder
+      STRIPE_SECRET_KEY: sk_test_placeholder
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_placeholder
+      STRIPE_WEBHOOK_SECRET: whsec_placeholder
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      BASE_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+      - run: npx prisma generate
+      - run: npx prisma migrate deploy
+      - run: npm run db:seed
+
+      - name: Install k6
+        run: |
+          sudo gpg -k
+          sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo 'deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main' | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update
+          sudo apt-get install -y k6
+
+      - run: npm run build
+      - run: npm run start > /tmp/next-start.log 2>&1 &
+      - run: npx wait-on tcp:3000 --timeout 120000 || (echo 'Server failed to start'; cat /tmp/next-start.log; exit 1)
+
+      - name: Execute CI load test
+        run: npm run test:load:ci
+
+      - name: Publish SLO baseline markdown
+        run: node scripts/ci/publish-load-baseline.mjs
+
+      - name: Upload load test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: load-test-baseline
+          path: |
+            tests/load/results/
+            docs/status/load-testing/slo-baseline-latest.md
+
+      - name: Add SLO baseline to step summary
+        if: always()
+        run: cat docs/status/load-testing/slo-baseline-latest.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/production-db-migrate.yml
+++ b/.github/workflows/production-db-migrate.yml
@@ -1,0 +1,55 @@
+name: Production DB Migrate
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this migration is being run"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  migrate-production:
+    name: Run prisma migrate deploy on production database
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+    steps:
+      - name: Validate production DB secret
+        run: |
+          if [ -z "${DATABASE_URL}" ]; then
+            echo "PRODUCTION_DATABASE_URL secret is not configured." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Apply production migrations
+        run: npx prisma migrate deploy
+
+      - name: Write summary
+        run: |
+          {
+            echo "## Production DB Migration"
+            echo "- Trigger reason: ${{ github.event.inputs.reason }}"
+            echo "- Command: npx prisma migrate deploy"
+            echo "- Status: success"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ops/ISSUES_174_176_178_179_192.md
+++ b/docs/ops/ISSUES_174_176_178_179_192.md
@@ -1,0 +1,79 @@
+# Issue Closure Runbook (#174, #176, #178, #179, #192)
+
+This document tracks the concrete implementation and operator steps required to close the listed production issues.
+
+## #174 — Prisma migrate deploy in production DB
+
+Implemented:
+- New manual workflow: `.github/workflows/production-db-migrate.yml`.
+- Production deploy workflow now includes a migration step using `PRODUCTION_DATABASE_URL` before Vercel deployment.
+
+Required secret:
+- `PRODUCTION_DATABASE_URL`
+
+Manual execution:
+1. GitHub → Actions → **Production DB Migrate**.
+2. Click **Run workflow** and include a change reason.
+3. Confirm the summary shows `npx prisma migrate deploy` completed.
+
+## #176 — Execute load tests + publish SLO baseline
+
+Implemented:
+- New workflow: `.github/workflows/load-test-baseline.yml`.
+- New SLO baseline publisher: `scripts/ci/publish-load-baseline.mjs`.
+- Output baseline artifact: `docs/status/load-testing/slo-baseline-latest.md`.
+
+How to run:
+1. GitHub → Actions → **Load Test + SLO Baseline**.
+2. Trigger manually (or wait for weekly schedule).
+3. Download `load-test-baseline` artifact and review SLO table.
+
+## #178 — Register Stripe webhook in Stripe dashboard
+
+Repository-side readiness:
+- Webhook endpoint path: `/api/stripe/webhook`.
+- Required production secret: `STRIPE_WEBHOOK_SECRET`.
+
+Manual Stripe dashboard steps:
+1. Stripe Dashboard → Developers → Webhooks → Add endpoint.
+2. URL: `https://<production-domain>/api/stripe/webhook`.
+3. Subscribe to events:
+   - `checkout.session.completed`
+   - `customer.subscription.created`
+   - `customer.subscription.updated`
+   - `customer.subscription.deleted`
+   - `invoice.payment_failed`
+4. Copy signing secret (`whsec_...`) into GitHub/Vercel `STRIPE_WEBHOOK_SECRET`.
+5. Send a test event from Stripe and verify 2xx response.
+
+## #179 — Source brand PNG assets
+
+Current canonical PNG assets are stored in `/public/brand`:
+- `rwfw-seal.png`
+- `5r-root.png`
+- `5r-regulate.png`
+- `5r-reflect.png`
+- `5r-restore.png`
+- `5r-reconnect.png`
+- `favicon.png`
+
+Source/provenance reference:
+- `docs/BRAND_AUDIT.md`
+
+## #192 — Add Clerk test credentials as GitHub Actions secrets
+
+Required GitHub repository secrets for stable Clerk E2E runs:
+- `CLERK_TESTING_TOKEN`
+- `CLERK_SECRET_KEY_TEST`
+- `CLERK_PUBLISHABLE_KEY_TEST`
+- `E2E_CLERK_USER_STUDENT_EMAIL`
+- `E2E_CLERK_USER_STUDENT_PASSWORD`
+- `E2E_CLERK_USER_EDUCATOR_EMAIL`
+- `E2E_CLERK_USER_EDUCATOR_PASSWORD`
+- `E2E_CLERK_USER_PARENT_EMAIL`
+- `E2E_CLERK_USER_PARENT_PASSWORD`
+- `E2E_CLERK_USER_ADMIN_EMAIL`
+- `E2E_CLERK_USER_ADMIN_PASSWORD`
+
+Recommended validation:
+- Run `.github/workflows/e2e-tests.yml` after secrets are created.

--- a/public/brand/ASSET_MANIFEST.md
+++ b/public/brand/ASSET_MANIFEST.md
@@ -1,0 +1,15 @@
+# Brand PNG Asset Manifest
+
+Canonical production PNG assets for RootWork branding.
+
+| Asset | Purpose |
+|---|---|
+| `rwfw-seal.png` | Primary RootWork seal logo |
+| `5r-root.png` | 5R phase icon: Root |
+| `5r-regulate.png` | 5R phase icon: Regulate |
+| `5r-reflect.png` | 5R phase icon: Reflect |
+| `5r-restore.png` | 5R phase icon: Restore |
+| `5r-reconnect.png` | 5R phase icon: Reconnect |
+| `favicon.png` | Browser favicon source PNG |
+
+Provenance details are tracked in `docs/BRAND_AUDIT.md`.

--- a/scripts/ci/publish-load-baseline.mjs
+++ b/scripts/ci/publish-load-baseline.mjs
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const resultsDir = path.resolve('tests/load/results');
+const outFile = path.resolve('docs/status/load-testing/slo-baseline-latest.md');
+
+const summaries = fs
+  .readdirSync(resultsDir)
+  .filter((file) => file.startsWith('summary-') && file.endsWith('.json'))
+  .sort();
+
+if (summaries.length === 0) {
+  throw new Error('No load test summary files found in tests/load/results.');
+}
+
+const latest = summaries[summaries.length - 1];
+const summaryPath = path.join(resultsDir, latest);
+const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+
+const pick = (obj, fallback = 'n/a') => (obj ?? fallback);
+const metric = (name) => summary.metrics?.[name]?.values ?? {};
+
+const req = metric('http_req_duration');
+const failed = metric('http_req_failed');
+const rps = metric('http_reqs');
+
+const now = new Date().toISOString();
+const content = `# SLO Baseline (Latest)\n\n- Generated at: ${now}\n- Source summary: \`${summaryPath.replace(process.cwd() + '/', '')}\`\n\n## Measured Baseline\n\n| Metric | Baseline | Target | Status |\n|---|---:|---:|---|\n| p95 latency (http_req_duration) | ${pick(req['p(95)'])} ms | < 500 ms | ${Number(req['p(95)']) < 500 ? 'PASS' : 'FAIL'} |\n| p99 latency (http_req_duration) | ${pick(req['p(99)'])} ms | < 1000 ms | ${Number(req['p(99)']) < 1000 ? 'PASS' : 'FAIL'} |\n| error rate (http_req_failed.rate) | ${pick(failed.rate)} | < 0.01 | ${Number(failed.rate) < 0.01 ? 'PASS' : 'FAIL'} |\n| throughput (http_reqs.rate) | ${pick(rps.rate)} req/s | > 50 req/s | ${Number(rps.rate) > 50 ? 'PASS' : 'FAIL'} |\n\n## Raw Extract\n\n\`\`\`json\n${JSON.stringify({
+  http_req_duration: req,
+  http_req_failed: failed,
+  http_reqs: rps,
+}, null, 2)}\n\`\`\`\n`;
+
+fs.mkdirSync(path.dirname(outFile), { recursive: true });
+fs.writeFileSync(outFile, content);
+console.log(`Wrote ${outFile}`);

--- a/tests/e2e/global.setup.ts
+++ b/tests/e2e/global.setup.ts
@@ -11,6 +11,19 @@ setup.setTimeout(60000); // sign-in involves network calls to Clerk
 
 const STORAGE_DIR = path.join(__dirname, '../../playwright/.clerk');
 
+const requiredClerkEnvForCi = [
+  'CLERK_TESTING_TOKEN',
+  'E2E_CLERK_USER_STUDENT_EMAIL',
+  'E2E_CLERK_USER_STUDENT_PASSWORD',
+  'E2E_CLERK_USER_EDUCATOR_EMAIL',
+  'E2E_CLERK_USER_EDUCATOR_PASSWORD',
+  'E2E_CLERK_USER_PARENT_EMAIL',
+  'E2E_CLERK_USER_PARENT_PASSWORD',
+  'E2E_CLERK_USER_ADMIN_EMAIL',
+  'E2E_CLERK_USER_ADMIN_PASSWORD',
+];
+
+
 export const storageStatePaths: Record<string, string> = {
   STUDENT: path.join(STORAGE_DIR, 'student.json'),
   EDUCATOR: path.join(STORAGE_DIR, 'educator.json'),
@@ -20,6 +33,13 @@ export const storageStatePaths: Record<string, string> = {
 
 // Step 1: Initialize Clerk testing token
 setup('initialize clerk testing', async ({}) => {
+  if (process.env.CI === 'true') {
+    const missing = requiredClerkEnvForCi.filter((name) => !process.env[name]);
+    if (missing.length > 0) {
+      throw new Error(`Missing required Clerk E2E env vars in CI: ${missing.join(', ')}`);
+    }
+  }
+
   await clerkSetup();
 });
 

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -14,11 +14,13 @@ interface TestUser {
   dbRole: string;
 }
 
+const fromEnv = (key: string, fallback: string) => process.env[key] || fallback;
+
 export const TEST_USERS: Record<UserRole, TestUser> = {
   STUDENT: {
     clerkUserId: '',
-    email: 'student.test@rootwork.edu',
-    password: 'RwFw$E2e_Ts9!xQp',
+    email: fromEnv('E2E_CLERK_USER_STUDENT_EMAIL', 'student.test@rootwork.edu'),
+    password: fromEnv('E2E_CLERK_USER_STUDENT_PASSWORD', 'changeme-student-password'),
     role: 'STUDENT',
     firstName: 'Alex',
     lastName: 'TestStudent',
@@ -26,8 +28,8 @@ export const TEST_USERS: Record<UserRole, TestUser> = {
   },
   EDUCATOR: {
     clerkUserId: '',
-    email: 'educator.test@rootwork.edu',
-    password: 'RwFw$E2e_Ts9!xQp',
+    email: fromEnv('E2E_CLERK_USER_EDUCATOR_EMAIL', 'educator.test@rootwork.edu'),
+    password: fromEnv('E2E_CLERK_USER_EDUCATOR_PASSWORD', 'changeme-educator-password'),
     role: 'EDUCATOR',
     firstName: 'Sarah',
     lastName: 'TestEducator',
@@ -35,8 +37,8 @@ export const TEST_USERS: Record<UserRole, TestUser> = {
   },
   PARENT: {
     clerkUserId: '',
-    email: 'parent.test@rootwork.edu',
-    password: 'RwFw$E2e_Ts9!xQp',
+    email: fromEnv('E2E_CLERK_USER_PARENT_EMAIL', 'parent.test@rootwork.edu'),
+    password: fromEnv('E2E_CLERK_USER_PARENT_PASSWORD', 'changeme-parent-password'),
     role: 'PARENT',
     firstName: 'Maria',
     lastName: 'TestParent',
@@ -44,8 +46,8 @@ export const TEST_USERS: Record<UserRole, TestUser> = {
   },
   SCHOOL_ADMIN: {
     clerkUserId: '',
-    email: 'admin.test@rootwork.edu',
-    password: 'RwFw$E2e_Ts9!xQp',
+    email: fromEnv('E2E_CLERK_USER_ADMIN_EMAIL', 'admin.test@rootwork.edu'),
+    password: fromEnv('E2E_CLERK_USER_ADMIN_PASSWORD', 'changeme-admin-password'),
     role: 'SCHOOL_ADMIN',
     firstName: 'Robert',
     lastName: 'TestAdmin',


### PR DESCRIPTION
### Motivation
- Close release-blocking operational issues by making production migrations explicit, publishing load-test SLO baselines, documenting Stripe webhook/brand asset steps, and stabilizing Clerk E2E credentials in CI. 

### Description
- Add a manual `Production DB Migrate` workflow at `.github/workflows/production-db-migrate.yml` that validates `PRODUCTION_DATABASE_URL` and runs `npx prisma migrate deploy` against production. 
- Run Prisma migrations during production deploy by adding an `Apply production database migrations` step to `.github/workflows/deploy.yml` that uses `PRODUCTION_DATABASE_URL` and runs `npx prisma migrate deploy` before the Vercel build. 
- Add a scheduled/manual `Load Test + SLO Baseline` workflow at `.github/workflows/load-test-baseline.yml` which boots a test DB, runs the app, executes k6 smoke load tests, and uploads results. 
- Add `scripts/ci/publish-load-baseline.mjs` to parse k6 JSON summaries and emit `docs/status/load-testing/slo-baseline-latest.md` (measured baseline table + raw extract). 
- Harden E2E Clerk handling for CI by wiring `CLERK_TESTING_TOKEN` and `E2E_CLERK_USER_*` secrets into the E2E workflow, moving test credentials to environment-driven values in `tests/helpers/auth.ts`, and adding CI fail-fast validation of required Clerk vars in `tests/e2e/global.setup.ts`. 
- Provide operator documentation and runbook for issues `#174`, `#176`, `#178`, `#179`, `#192` at `docs/ops/ISSUES_174_176_178_179_192.md`, and add a canonical brand PNG inventory at `public/brand/ASSET_MANIFEST.md`. 

### Testing
- Ran lint: `npm run lint` — passed. 
- Ran type check: `npx tsc --noEmit` — failed with pre-existing unrelated type errors in test/integration files; failures are not introduced by these operational changes. 
- Confirmed workflows include `npx prisma migrate deploy` and the load-test job invokes `npm run test:load:ci` and `node scripts/ci/publish-load-baseline.mjs` (CI-only validation to be verified when secrets and k6 results are available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0fd9c47b8832aacd6519403b6b374)