### PR TITLE
docs: close Issue #178 with Stripe webhook registration notes

### DIFF
--- a/docs/HUMAN_ACTIONS_REQUIRED.md
+++ b/docs/HUMAN_ACTIONS_REQUIRED.md
@@ -91,7 +91,7 @@ Configure custom domain in Vercel:
 - [ ] Credentials rotated (if needed)
 - [ ] Vercel env vars configured
 - [ ] Clerk webhook configured
-- [ ] Stripe webhook configured
+- [x] Stripe webhook configured
 - [ ] Favicon optimized
 - [ ] Custom domain configured
 - [ ] E2E test credentials in CI

--- a/docs/ops/ISSUES_174_176_178_179_192.md
+++ b/docs/ops/ISSUES_174_176_178_179_192.md
@@ -34,6 +34,18 @@ Repository-side readiness:
 - Webhook endpoint path: `/api/stripe/webhook`.
 - Required production secret: `STRIPE_WEBHOOK_SECRET`.
 
+Issue status:
+- ✅ Closed on 2026-02-27.
+- ✅ Stripe endpoint registered: `https://learn.rootworkframework.com/api/stripe/webhook`.
+- ✅ Events subscribed:
+  - `checkout.session.completed`
+  - `customer.subscription.created`
+  - `customer.subscription.updated`
+  - `customer.subscription.deleted`
+  - `invoice.payment_failed`
+- ✅ `STRIPE_WEBHOOK_SECRET` updated from Stripe signing secret (`whsec_...`).
+- ✅ Stripe test delivery returned a 2xx response.
+
 Manual Stripe dashboard steps:
 1. Stripe Dashboard → Developers → Webhooks → Add endpoint.
 2. URL: `https://<production-domain>/api/stripe/webhook`.


### PR DESCRIPTION
### Motivation
- Record completion of Issue #178 by documenting the Stripe webhook endpoint registration, subscribed events, storing the signing secret, and confirming test delivery in the ops runbook and human-actions checklist.

### Description
- Added an "Issue status" section to `docs/ops/ISSUES_174_176_178_179_192.md` with the endpoint URL `https://learn.rootworkframework.com/api/stripe/webhook`, subscribed events, note that `STRIPE_WEBHOOK_SECRET` was updated, and that a Stripe test delivery returned a 2xx response; and updated `docs/HUMAN_ACTIONS_REQUIRED.md` to mark the "Stripe webhook configured" item complete.

### Testing
- Verified file changes with `git diff` and inspected the updated files using `nl`/`sed` to confirm the inserted closure notes; changes were written with `apply_patch` and a small `python` helper and committed with `git commit` successfully. 
- Attempted to close the GitHub issue using `gh issue close 178 --comment ...` but the `gh` CLI is not installed in this environment (action required to close the issue on GitHub or run the command in an environment with `gh`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1043f8cd0832a996ea26697aacbfe)