### PR TITLE
docs: clarify blockers for issues #174/#176/#178/#179/#189/#192

### DIFF
--- a/docs/HUMAN_ACTIONS_REQUIRED.md
+++ b/docs/HUMAN_ACTIONS_REQUIRED.md
@@ -71,14 +71,29 @@ Create a 1200x630px Open Graph image for social sharing using brand assets. Plac
 ## Priority 4 — CI/CD
 
 ### 9. Clerk E2E Test Credentials
-Add Clerk test instance credentials to GitHub Actions secrets:
-- `CLERK_PUBLISHABLE_KEY_TEST`
-- `CLERK_SECRET_KEY_TEST`
-- `E2E_CLERK_PUBLISHABLE_KEY_TEST` (optional E2E-specific override)
-- `E2E_CLERK_SECRET_KEY_TEST` (optional E2E-specific override)
-- `CLERK_TESTING_TOKEN`
-- `E2E_CLERK_USER_*` variables
-- Full checklist: `docs/ops/ISSUES_174_176_178_179_192.md`
+Add Clerk test instance credentials to GitHub Actions secrets.
+
+Required secrets (blocking issue #192 / Phase 0):
+
+| Secret | Required |
+| --- | --- |
+| `CLERK_TESTING_TOKEN` | Yes |
+| `E2E_CLERK_USER_STUDENT_EMAIL` | Yes |
+| `E2E_CLERK_USER_STUDENT_PASSWORD` | Yes |
+| `E2E_CLERK_USER_EDUCATOR_EMAIL` | Yes |
+| `E2E_CLERK_USER_EDUCATOR_PASSWORD` | Yes |
+| `E2E_CLERK_USER_PARENT_EMAIL` | Yes |
+| `E2E_CLERK_USER_PARENT_PASSWORD` | Yes |
+| `E2E_CLERK_USER_ADMIN_EMAIL` | Yes |
+| `E2E_CLERK_USER_ADMIN_PASSWORD` | Yes |
+| `CLERK_PUBLISHABLE_KEY_TEST` | Yes |
+| `CLERK_SECRET_KEY_TEST` | Yes |
+
+Optional overrides:
+- `E2E_CLERK_PUBLISHABLE_KEY_TEST`
+- `E2E_CLERK_SECRET_KEY_TEST`
+
+After provisioning, trigger `.github/workflows/e2e-tests.yml`; Phase 0 should go green automatically once these values are present.
 
 ### 10. Custom Domain
 Configure custom domain in Vercel:

--- a/docs/ops/ISSUES_174_176_178_179_192.md
+++ b/docs/ops/ISSUES_174_176_178_179_192.md
@@ -1,6 +1,20 @@
-# Issue Closure Runbook (#174, #176, #178, #179, #192)
+# Issue Closure Runbook (#174, #176, #178, #179, #189, #192)
 
 This document tracks the concrete implementation and operator steps required to close the listed production issues.
+
+## Current blockers snapshot
+
+| Issue | Blocker | Human action to unblock |
+| --- | --- | --- |
+| #174 | Production DB access | Set `PRODUCTION_DATABASE_URL` in the GitHub **production** environment, then run the **Production DB Migrate** workflow. |
+| #176 | Staging environment execution | Run `load-test-baseline.yml` against staging; workflow output should publish to `docs/status/load-testing/slo-baseline-latest.md`. |
+| #179 | Design asset sourcing | Source and commit the PNG files specified in `public/brand/ASSET_MANIFEST.md`. |
+| #189 | Datadog provisioning | Set `DATADOG_STATSD_HOST` (optionally `DATADOG_STATSD_PORT`, `DATADOG_METRIC_PREFIX`) in Vercel environment variables. |
+| #192 | CI secrets | Add all `E2E_CLERK_USER_*` secrets plus `CLERK_TESTING_TOKEN` in GitHub Actions (see table in `docs/HUMAN_ACTIONS_REQUIRED.md`, section 9). |
+| #178 | `gh` authentication | Run `gh issue close 178` after CLI authentication is available. |
+
+Phase 0 dependency:
+- #192 is the gate for a green E2E CI run; once these secrets are provisioned, the follow-up run should pass without further repository changes.
 
 ## #174 — Prisma migrate deploy in production DB
 
@@ -28,14 +42,13 @@ How to run:
 2. Trigger manually (or wait for weekly schedule).
 3. Download `load-test-baseline` artifact and review SLO table.
 
-## #178 — Register Stripe webhook in Stripe dashboard
+## #178 — Register Stripe webhook in Stripe dashboard / close issue with gh CLI
 
 Repository-side readiness:
 - Webhook endpoint path: `/api/stripe/webhook`.
 - Required production secret: `STRIPE_WEBHOOK_SECRET`.
 
 Issue status:
-- ✅ Closed on 2026-02-27.
 - ✅ Stripe endpoint registered: `https://learn.rootworkframework.com/api/stripe/webhook`.
 - ✅ Events subscribed:
   - `checkout.session.completed`
@@ -45,6 +58,7 @@ Issue status:
   - `invoice.payment_failed`
 - ✅ `STRIPE_WEBHOOK_SECRET` updated from Stripe signing secret (`whsec_...`).
 - ✅ Stripe test delivery returned a 2xx response.
+- ⏳ Pending operator action: run `gh issue close 178` once authenticated.
 
 Manual Stripe dashboard steps:
 1. Stripe Dashboard → Developers → Webhooks → Add endpoint.
@@ -71,6 +85,19 @@ Current canonical PNG assets are stored in `/public/brand`:
 
 Source/provenance reference:
 - `docs/BRAND_AUDIT.md`
+
+Required sourcing checklist:
+- `public/brand/ASSET_MANIFEST.md`
+
+## #189 — Datadog StatsD env wiring
+
+Repository readiness:
+- Runtime metrics support accepts host/port/prefix from env vars.
+
+Required Vercel production environment variables:
+- `DATADOG_STATSD_HOST` (required)
+- `DATADOG_STATSD_PORT` (optional)
+- `DATADOG_METRIC_PREFIX` (optional)
 
 ## #192 — Add Clerk test credentials as GitHub Actions secrets
 


### PR DESCRIPTION
### Motivation
- Make operator-required unblock steps explicit for several open ops issues by adding a concise blockers snapshot and wiring notes. 
- Surface the Phase 0 dependency that provisioning Clerk E2E secrets unblocks a green E2E CI run.
- Record a pending `gh` CLI action for #178 so operators know closing the issue requires authenticated CLI access.

### Description
- Added a `Current blockers snapshot` table to `docs/ops/ISSUES_174_176_178_179_192.md` that lists issues #174, #176, #179, #189, #192, and #178 with exact human actions to unblock each. 
- Updated the #178 Stripe webhook section to mark the webhook as registered but note the pending operator action to run `gh issue close 178` once authenticated. 
- Added a short #189 section documenting required Datadog StatsD environment variables (`DATADOG_STATSD_HOST`, optional `DATADOG_STATSD_PORT`, `DATADOG_METRIC_PREFIX`). 
- Expanded `docs/HUMAN_ACTIONS_REQUIRED.md` section 9 with a concrete table enumerating the 11 required Clerk E2E secrets plus optional overrides and a post-provisioning instruction to trigger `.github/workflows/e2e-tests.yml`.

### Testing
- Verified the documentation diffs with `git diff` which showed the expected insertions and updates and the command completed successfully. 
- Confirmed file contents via `nl -ba` / `sed` printouts for both modified files which displayed the new table and sections as intended. 
- Ran `git status --short` to confirm the working tree contained the intended changes and staging; the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10a7a5184832aae9bf9691e10e4f7)