### PR TITLE
Fix CSP headers for production Clerk custom domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -47,7 +47,7 @@ const nextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.clerk.io https://*.clerk.accounts.dev https://js.stripe.com https://challenges.cloudflare.com https://vercel.live; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.clerk.com https://images.unsplash.com; font-src 'self' https://vercel.live; connect-src 'self' https://api.clerk.io https://*.clerk.accounts.dev https://api.stripe.com https://*.pinecone.io https://api.anthropic.com https://api.openai.com https://challenges.cloudflare.com https://vercel.live; frame-src https://js.stripe.com https://accounts.clerk.dev https://*.clerk.accounts.dev https://challenges.cloudflare.com https://vercel.live; object-src 'none'; base-uri 'self'; form-action 'self';",
+              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://clerk.rwfw-learninghub.com https://js.stripe.com https://challenges.cloudflare.com https://vercel.live; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.clerk.com https://images.unsplash.com; font-src 'self' https://vercel.live; connect-src 'self' https://clerk.rwfw-learninghub.com https://accounts.rwfw-learninghub.com https://api.stripe.com https://*.pinecone.io https://api.anthropic.com https://api.openai.com https://challenges.cloudflare.com https://vercel.live; frame-src https://js.stripe.com https://accounts.rwfw-learninghub.com https://challenges.cloudflare.com https://vercel.live; object-src 'none'; base-uri 'self'; form-action 'self';",
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Replaces hardcoded `clerk.accounts.dev` test origins with production `clerk.rwfw-learninghub.com` and `accounts.rwfw-learninghub.com` in `script-src`, `connect-src`, and `frame-src` CSP directives
- Part of Clerk instance/key fix across RWFW-LOS and learning-hub

## Test plan
- [x] Both apps deployed to production with correct live Clerk key pairs
- [x] All Clerk DNS records added and verified (clerk.*, accounts.*, clkmail.*, DKIM)
- [x] Sign-in pages return HTTP 200 with `X-Clerk-Auth-Status: signed-out`

🤖 Generated with [Claude Code](https://claude.com/claude-code)