### PR TITLE
Wire E2E Clerk test users and Datadog HTTP API metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,15 +77,19 @@ SENTRY_ORG=
 SENTRY_PROJECT=
 
 # Datadog APM (optional — leave blank to disable)
+# Datadog — HTTP API (preferred for Vercel serverless, no agent required)
+# Get from: https://app.datadoghq.com/organization-settings/api-keys
+DATADOG_API_KEY=
+DATADOG_SITE=datadoghq.com
+DATADOG_METRIC_PREFIX=rootwork
+
+# Datadog — legacy StatsD/UDP (requires a running Datadog Agent, not recommended for serverless)
 DD_API_KEY=
 DD_APP_KEY=
-DD_SITE=datadoghq.com
 DD_SERVICE=rootwork-tutor
 DD_ENV=production
-# Datadog StatsD host for metrics push (set DATADOG_STATSD_HOST to enable cross-instance metrics)
 DATADOG_STATSD_HOST=
 DATADOG_STATSD_PORT=8125
-DATADOG_METRIC_PREFIX=rootwork
 
 # Alerting (optional — leave blank to disable channels)
 SLACK_WEBHOOK_URL=

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,7 +35,8 @@ jobs:
       DIRECT_URL: postgresql://rootwork:rootwork_e2e@localhost:5432/rootwork_test?schema=public
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_TEST }}
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_TEST }}
-      CLERK_TESTING_TOKEN: ${{ secrets.CLERK_TESTING_TOKEN }}
+      # CLERK_TESTING_TOKEN is generated dynamically in the "Generate Clerk testing token" step
+      # because it is short-lived (~1 hour). Do not store as a static secret.
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || 'sk-ant-placeholder' }}
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY_TEST || 'sk_test_placeholder' }}
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY_TEST || 'pk_test_placeholder' }}
@@ -64,19 +65,29 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
-      
+
+      - name: Generate Clerk testing token
+        id: clerk_token
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_TEST }}
+        run: |
+          TOKEN=$(curl -s -X POST "https://api.clerk.com/v1/testing_tokens" \
+            -H "Authorization: Bearer $CLERK_SECRET_KEY" \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['token'])")
+          echo "CLERK_TESTING_TOKEN=$TOKEN" >> $GITHUB_ENV
+
       - name: Generate Prisma client
         run: npx prisma generate
-      
+
       - name: Run database migrations
         run: npx prisma migrate deploy
-      
+
       - name: Seed database with test data
         run: npm run db:seed
-      
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      
+
       - name: Run E2E tests
         run: |
           npm run build

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -61,10 +61,10 @@ async function main() {
 
   // Create Educator
   const educatorUser = await prisma.user.upsert({
-    where: { clerkUserId: 'clerk_educator_demo_001' },
+    where: { clerkUserId: 'user_3Ai5XDH3K8rnNEYFiiT9M9c4jvt' },
     update: {},
     create: {
-      clerkUserId: 'clerk_educator_demo_001',
+      clerkUserId: 'user_3Ai5XDH3K8rnNEYFiiT9M9c4jvt',
       tenantId: tenant.id,
       schoolId: school.id,
       email: 'ms.johnson@demo.rootwork.edu',
@@ -91,7 +91,7 @@ async function main() {
   // Create Students
   const studentData = [
     {
-      clerkUserId: 'clerk_student_demo_001',
+      clerkUserId: 'user_3Ai5YXMpcwlOrFED37kx6C4vZUO',
       email: 'alex.martinez@demo.rootwork.edu',
       firstName: 'Alex',
       lastName: 'Martinez',
@@ -108,7 +108,7 @@ async function main() {
       },
     },
     {
-      clerkUserId: 'clerk_student_demo_002',
+      clerkUserId: 'user_3Ai5Yj6GJ4SKxkczueNHFfJ9U96',
       email: 'jordan.lee@demo.rootwork.edu',
       firstName: 'Jordan',
       lastName: 'Lee',
@@ -125,7 +125,7 @@ async function main() {
       },
     },
     {
-      clerkUserId: 'clerk_student_demo_003',
+      clerkUserId: 'user_3Ai5Yu0X5oA1lL4W6JsHadz8iVn',
       email: 'taylor.smith@demo.rootwork.edu',
       firstName: 'Taylor',
       lastName: 'Smith',
@@ -231,10 +231,10 @@ async function main() {
 
   // Create Parent User (linked to Alex Martinez)
   const parentUser = await prisma.user.upsert({
-    where: { clerkUserId: 'clerk_parent_demo_001' },
+    where: { clerkUserId: 'user_3Ai5YvEjVi0F9LABoOTX0LCOeRr' },
     update: {},
     create: {
-      clerkUserId: 'clerk_parent_demo_001',
+      clerkUserId: 'user_3Ai5YvEjVi0F9LABoOTX0LCOeRr',
       tenantId: tenant.id,
       schoolId: school.id,
       email: 'parent@demo.rootwork.edu',
@@ -264,10 +264,10 @@ async function main() {
 
   // Create Admin User
   const adminUser = await prisma.user.upsert({
-    where: { clerkUserId: 'clerk_admin_demo_001' },
+    where: { clerkUserId: 'user_3Ai5Z2zol0AJa4RJy16IE9pGbfY' },
     update: {},
     create: {
-      clerkUserId: 'clerk_admin_demo_001',
+      clerkUserId: 'user_3Ai5Z2zol0AJa4RJy16IE9pGbfY',
       tenantId: tenant.id,
       schoolId: school.id,
       email: 'admin@demo.rootwork.edu',

--- a/src/lib/monitoring/metrics.ts
+++ b/src/lib/monitoring/metrics.ts
@@ -18,10 +18,40 @@ import { alertRules, checkAlertCondition, sendAlert } from './alerts';
 // ---------------------------------------------------------------------------
 
 /**
- * Push a gauge or counter to Datadog via UDP StatsD.
- * Only active when DATADOG_STATSD_HOST is set.
+ * Push a metric to Datadog via HTTP API (v2/series).
+ * Works in Vercel serverless where UDP StatsD is unreliable.
+ * Requires DATADOG_API_KEY env var. DATADOG_SITE defaults to datadoghq.com.
  * Fire-and-forget: errors are swallowed so metric failures never affect
  * request latency or availability.
+ */
+function pushToDatadog(metric: string, value: number): void {
+  const apiKey = process.env.DATADOG_API_KEY;
+  if (!apiKey) return;
+
+  const site = process.env.DATADOG_SITE ?? 'datadoghq.com';
+  const prefix = process.env.DATADOG_METRIC_PREFIX ?? 'rootwork';
+  const env = process.env.NODE_ENV ?? 'development';
+  const now = Math.floor(Date.now() / 1000);
+
+  const body = JSON.stringify({
+    series: [{
+      metric: `${prefix}.${metric}`,
+      type: 0, // UNSPECIFIED (gauge)
+      points: [{ timestamp: now, value }],
+      tags: [`env:${env}`],
+    }],
+  });
+
+  fetch(`https://api.${site}/api/v2/series`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'DD-API-KEY': apiKey },
+    body,
+  }).catch(() => {/* swallow — never affect request path */});
+}
+
+/**
+ * @deprecated UDP StatsD is unreliable in serverless. Use DATADOG_API_KEY instead.
+ * Kept for backwards-compat with any self-hosted agent deployments.
  */
 function pushToStatsd(metric: string, value: number, type: 'g' | 'c' = 'g'): void {
   const host = process.env.DATADOG_STATSD_HOST;
@@ -54,7 +84,9 @@ class MetricsStore {
   private readonly MAX_SAMPLES = 1000;
 
   record(metric: string, value: number, timestamp: number = Date.now()) {
-    // Push to external aggregator (no-op when DATADOG_STATSD_HOST not set)
+    // Push to Datadog via HTTP API (preferred for serverless, no-op when DATADOG_API_KEY not set)
+    pushToDatadog(metric, value);
+    // Legacy UDP StatsD (no-op when DATADOG_STATSD_HOST not set)
     pushToStatsd(metric, value);
 
     if (!this.metrics.has(metric)) {


### PR DESCRIPTION
## Summary

### Clerk E2E (#192)
- Created 6 Clerk test users in the dev instance (educator, 3 students, parent, admin) using the Clerk Backend API
- Updated `prisma/seed.ts` with real Clerk user IDs — seed DB now matches actual Clerk auth identities
- Refreshed all 8 `E2E_CLERK_USER_*` GitHub secrets + `CLERK_PUBLISHABLE_KEY_TEST` / `CLERK_SECRET_KEY_TEST`
- Changed `CLERK_TESTING_TOKEN` from a static secret to a **dynamically generated step** in the E2E workflow (the token has a ~1 hour TTL and cannot be stored statically)

### Datadog (#189)
- Upgraded `metrics.ts` to push via Datadog HTTP API (`POST /api/v2/series` with `DATADOG_API_KEY`) — works in Vercel serverless where UDP StatsD is unreliable
- Legacy UDP StatsD path retained for backwards compatibility with self-hosted agent deployments
- `DATADOG_SITE=datadoghq.com` and `DATADOG_METRIC_PREFIX=rootwork` set in Vercel env vars
- `.env.example` updated to document `DATADOG_API_KEY` as the primary integration point

## One remaining manual step
Add `DATADOG_API_KEY` to Vercel → project settings → Environment Variables (production + preview):
1. Go to https://app.datadoghq.com/organization-settings/api-keys
2. Create or copy an API key
3. Set `DATADOG_API_KEY=<key>` in Vercel for production and preview environments

Once set, all `metricsStore.record(...)` calls will push to Datadog automatically with no further code changes.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] E2E workflow run on merge to main — will exercise dynamic testing token generation and real Clerk auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)